### PR TITLE
Docs: fix README setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,7 @@ KEYPATH="/home/<user>/certs/localhost+2-key.pem"
 
 # ===============================================================#
 
-PAYMENT_SERVICE="PAYMONGO"
+PAYMENT_SERVICE="PAYMONGO" # Required
 PAYMONGO_BASE_URL="https://api.paymongo.com/v1"
 PAYMONGO_API_KEY="sk_test_"
 PAYMONGO_WEBHOOK_SECRET_KEY=""
@@ -34,15 +34,15 @@ PAYMONGO_SUCCESS_URL="https://test.com/cchoice/payments/success"
 PAYMONGO_CANCEL_URL="https://test.com/cchoice/payments/cancel"
 
 # LALAMOVE, CCHOICE
-SHIPPING_SERVICE="LALAMOVE"
+SHIPPING_SERVICE="LALAMOVE" # Required
 LALAMOVE_BASE_URL="https://rest.sandbox.lalamove.com"
 LALAMOVE_API_KEY="pk_test_"
 LALAMOVE_API_SECRET="sk_test_"
 
-GEOCODING_SERVICE="GOOGLEMAPS"
+GEOCODING_SERVICE="GOOGLEMAPS" # Required
 GOOGLE_MAPS_API_KEY=""
 
-# Business Location Configuration
+# Business Location Configuration (Required)
 BUSINESS_LAT=""
 BUSINESS_LNG=""
 BUSINESS_ADDRESS=""
@@ -84,10 +84,10 @@ MAILEROO_CC="" # comma-separated values
 # embeddedfs = serve files embedded in binary (requires build tag "embeddedfs")
 # staticfs = serve files from disk (requires build tag "staticfs")
 # s3 = serve files from AWS S3
-FSMODE="staticfs"
+FSMODE="staticfs" # Required
 
 # Sqids
-ENCODE_SALT="abc123"
+ENCODE_SALT="abc123" # Required
 
 GOOSE_DRIVER="sqlite3"
 GOOSE_DBSTRING="file:./test.db" # must match $DB_URL

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 - `go install github.com/magefile/mage@latest`
 - `mage deps`
 - `mage setup`
-    - If you get `cp: cannot create regular file './git/hooks/pre-commit': No such file or directory
-    Error: exit status 1` open `magefile.go` find line 280 and change `./git/hooks/pre-commit` to `./.git/hooks/pre-commit` and run     `mage setup` again.
-    - **Important**: After running `mage setup`, you MUST edit `.env` and fill in the `BUSINESS_*` variables. The application will 
-    panic on startup if these are empty.
 - `mage setupprod`
 - `mage genall`
 - `mage cleandb`
@@ -19,17 +15,15 @@
 - `mage genmaps`
 - `mage testall`
 - `mage benchmark`
-    
-- Add "Env Vars" Details
-Update the current brief reference:
+
 # Env Vars
+
 See `.env.sample`
-**Mandatory Fields (must be filled in `.env`):**
-- `BUSINESS_LAT`, `BUSINESS_LNG`, `BUSINESS_ADDRESS`, `BUSINESS_LINE1`, `BUSINESS_LINE2`, `BUSINESS_CITY`, `BUSINESS_STATE`, `BUSINESS_POSTAL_CODE`, `BUSINESS_COUNTRY`
 
 # Running
-- NOTE: if you don't have `vivaldi` browser, open `magefile.go` find this line `browser = getenv("BROWSER", "vivaldi")` 
-change `vivaldi` to your preferred browser (e.g., `browser = getenv("BROWSER", "chrome")`).   
+
+Users should set their own `BROWSER` env var in their shell. Example: `export BROWSER=chrome`
+
 - run `mage serve`
 - or `mage serveweb` for faster iteration for frontend changes only
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Setup
 
 - `git clone --recurse-submodules --shallow-submodules -j8 <repo url>`
+- `cd cchoice`
 - `go mod download`
 - `go mod tidy`
 - `go install tool`
 - `go install github.com/magefile/mage@latest`
 - `mage deps`
 - `mage setup`
+    - If you get `cp: cannot create regular file './git/hooks/pre-commit': No such file or directory
+    Error: exit status 1` open `magefile.go` find line 280 and change `./git/hooks/pre-commit` to `./.git/hooks/pre-commit` and run     `mage setup` again.
+    - **Important**: After running `mage setup`, you MUST edit `.env` and fill in the `BUSINESS_*` variables. The application will 
+    panic on startup if these are empty.
 - `mage setupprod`
 - `mage genall`
 - `mage cleandb`
@@ -14,13 +19,17 @@
 - `mage genmaps`
 - `mage testall`
 - `mage benchmark`
-
+    
+- Add "Env Vars" Details
+Update the current brief reference:
 # Env Vars
-
 See `.env.sample`
+**Mandatory Fields (must be filled in `.env`):**
+- `BUSINESS_LAT`, `BUSINESS_LNG`, `BUSINESS_ADDRESS`, `BUSINESS_LINE1`, `BUSINESS_LINE2`, `BUSINESS_CITY`, `BUSINESS_STATE`, `BUSINESS_POSTAL_CODE`, `BUSINESS_COUNTRY`
 
 # Running
-
+- NOTE: if you don't have `vivaldi` browser, open `magefile.go` find this line `browser = getenv("BROWSER", "vivaldi")` 
+change `vivaldi` to your preferred browser (e.g., `browser = getenv("BROWSER", "chrome")`).   
 - run `mage serve`
 - or `mage serveweb` for faster iteration for frontend changes only
 

--- a/magefile.go
+++ b/magefile.go
@@ -277,7 +277,7 @@ func BuildGoose() error {
 }
 
 func Setup() error {
-	const pathPreCommitHook = "./git/hooks/pre-commit"
+	const pathPreCommitHook = "./.git/hooks/pre-commit"
 	if _, err := os.Stat(pathPreCommitHook); os.IsNotExist(err) {
 		if err := run(Command{Type: CmdExec, Cmd: "cp", Args: []string{"./scripts/pre-commit-unit-test.sh", pathPreCommitHook}}); err != nil {
 			return err


### PR DESCRIPTION
## Describe your changes
- Fixed the mage setup task fails to write the pre-commit hook because it references ./git/hooks/pre-commit rather than ./.git/hooks/pre-commit
- Added documentation in README.md about users should set their own `BROWSER` env var in their shell. Example: `export BROWSER=chrome`


## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
![fb9c9c69-f68c-4a8a-a1d8-0ce01c275047](https://github.com/user-attachments/assets/636d922a-379b-4718-b8ed-cbca24c6ec92)
[https://drive.google.com/file/d/1K6zGYds3Er3yuzEKp32spcMVAM5WSK0N/view?usp=sharing](url)
