### PR TITLE
Script: Fixed go build flag ordering and tag formatting

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -60,10 +60,10 @@ func run(c Command) error {
 		}
 		// args = append(args, "-x")
 		// args = append(args, "-v")
-		args = append(args, c.Args...)
 		if len(c.Tags) > 0 {
-			args = append(args, "-tags="+strings.Join(c.Tags, " "))
+			args = append(args, "-tags="+strings.Join(c.Tags, ","))
 		}
+		args = append(args, c.Args...)
 		cmd = exec.Command("go", args...)
 
 	case CmdGoRun:


### PR DESCRIPTION
## Describe your changes
1. Update the run function's CmdGoBuild case to move `args = append(args, c.Args...)` to the end (after -tags).
2. Change `strings.Join(c.Tags, " ")` to `strings.Join(c.Tags, ",")` for `CmdGoBuild` 
## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
![7d9441ce-1548-4e88-935f-4e22f0639552](https://github.com/user-attachments/assets/6aef2e91-1b47-4081-bf33-7622d7baa958)
![ce311b4c-6fd4-4753-9d6c-11257e523700](https://github.com/user-attachments/assets/3e4ba7ba-95be-4d5e-a3c5-b8b0197b3c8b)

