### PR TITLE
Docs: Fix mage setup task writing pre-commit hook to incorrect path

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,7 @@ KEYPATH="/home/<user>/certs/localhost+2-key.pem"
 
 # ===============================================================#
 
-PAYMENT_SERVICE="PAYMONGO"
+PAYMENT_SERVICE="PAYMONGO" #Required
 PAYMONGO_BASE_URL="https://api.paymongo.com/v1"
 PAYMONGO_API_KEY="sk_test_"
 PAYMONGO_WEBHOOK_SECRET_KEY=""
@@ -34,15 +34,15 @@ PAYMONGO_SUCCESS_URL="https://test.com/cchoice/payments/success"
 PAYMONGO_CANCEL_URL="https://test.com/cchoice/payments/cancel"
 
 # LALAMOVE, CCHOICE
-SHIPPING_SERVICE="LALAMOVE"
+SHIPPING_SERVICE="LALAMOVE" # Required
 LALAMOVE_BASE_URL="https://rest.sandbox.lalamove.com"
 LALAMOVE_API_KEY="pk_test_"
 LALAMOVE_API_SECRET="sk_test_"
 
-GEOCODING_SERVICE="GOOGLEMAPS"
+GEOCODING_SERVICE="GOOGLEMAPS" # Required
 GOOGLE_MAPS_API_KEY=""
 
-# Business Location Configuration
+# Business Location Configuration (Required)
 BUSINESS_LAT=""
 BUSINESS_LNG=""
 BUSINESS_ADDRESS=""
@@ -84,10 +84,10 @@ MAILEROO_CC="" # comma-separated values
 # embeddedfs = serve files embedded in binary (requires build tag "embeddedfs")
 # staticfs = serve files from disk (requires build tag "staticfs")
 # s3 = serve files from AWS S3
-FSMODE="staticfs"
+FSMODE="staticfs" # Required
 
 # Sqids
-ENCODE_SALT="abc123"
+ENCODE_SALT="abc123" # Required
 
 GOOSE_DRIVER="sqlite3"
 GOOSE_DBSTRING="file:./test.db" # must match $DB_URL

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Setup
 
 - `git clone --recurse-submodules --shallow-submodules -j8 <repo url>`
+- `cd cchoice`
 - `go mod download`
 - `go mod tidy`
 - `go install tool`
@@ -21,6 +22,7 @@ See `.env.sample`
 
 # Running
 
+Users should set their own `BROWSER` env var in their shell. Example: `export BROWSER=chrome`
 - run `mage serve`
 - or `mage serveweb` for faster iteration for frontend changes only
 

--- a/magefile.go
+++ b/magefile.go
@@ -299,7 +299,7 @@ func BuildGoose() error {
 }
 
 func Setup() error {
-	const pathPreCommitHook = "./git/hooks/pre-commit"
+	const pathPreCommitHook = "./.git/hooks/pre-commit"
 	if _, err := os.Stat(pathPreCommitHook); os.IsNotExist(err) {
 		if err := run(Command{Type: CmdExec, Cmd: "cp", Args: []string{"./scripts/pre-commit-unit-test.sh", pathPreCommitHook}}); err != nil {
 			return err


### PR DESCRIPTION
## Describe your changes
Fix `mage setup` task writing pre-commit hook to incorrect path and added `README.md` documentation instructing users to set their own `BROWSER` env var and Document required environment variables in `.env.sample`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
![14bdaca8-0cc8-4b19-8666-46b1941940e6](https://github.com/user-attachments/assets/4c0258bd-5e4b-42a8-9a4b-3c8be9fc3a23)
[https://drive.google.com/file/d/1K6zGYds3Er3yuzEKp32spcMVAM5WSK0N/view?usp=sharing](url)