### PR TITLE
Maintenance:  Centralize AttendanceService and ReportService in Server struct

### DIFF
--- a/internal/server/admin_staff.go
+++ b/internal/server/admin_staff.go
@@ -436,8 +436,7 @@ func (s *Server) adminStaffTimeInHandler(w http.ResponseWriter, r *http.Request)
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	err := s.services.attendance.TimeIn(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
-	if err != nil {
+	if err := s.services.attendance.TimeIn(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID); err != nil {
 		http.Error(w, "Unable to time in", http.StatusBadRequest)
 		return
 	}
@@ -450,8 +449,7 @@ func (s *Server) adminStaffTimeOutHandler(w http.ResponseWriter, r *http.Request
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	err := s.services.attendance.TimeOut(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
-	if err != nil {
+	if err := s.services.attendance.TimeOut(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID); err != nil {
 		http.Error(w, "Unable to time out", http.StatusBadRequest)
 		return
 	}
@@ -466,8 +464,7 @@ func (s *Server) adminStaffLunchBreakInHandler(w http.ResponseWriter, r *http.Re
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	err := s.services.attendance.LunchBreakIn(ctx, staffID, date, now, location, useragentID)
-	if err != nil {
+	if err := s.services.attendance.LunchBreakIn(ctx, staffID, date, now, location, useragentID); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
 			zap.Error(err),
@@ -488,8 +485,7 @@ func (s *Server) adminStaffLunchBreakOutHandler(w http.ResponseWriter, r *http.R
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	err := s.services.attendance.LunchBreakOut(ctx, staffID, date, now, location, useragentID)
-	if err != nil {
+	if err := s.services.attendance.LunchBreakOut(ctx, staffID, date, now, location, useragentID); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
 			zap.Error(err),

--- a/internal/server/admin_staff.go
+++ b/internal/server/admin_staff.go
@@ -258,8 +258,7 @@ func (s *Server) adminStaffPageHandler(w http.ResponseWriter, r *http.Request) {
 		hasLunchBreakIn = attendance.LunchBreakIn.Valid
 		hasLunchBreakOut = attendance.LunchBreakOut.Valid
 
-		attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, nil)
-		rec := attendanceService.ComputeData(
+		rec := s.services.attendance.ComputeData(
 			staffmodels.StaffRowBase(staff),
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
@@ -352,8 +351,7 @@ func (s *Server) adminStaffAttendanceTableHandler(w http.ResponseWriter, r *http
 	attendance, err := s.services.staff.GetAttendanceByDate(ctx, staff.ID, date)
 	var record *models.Attendance
 	if err == nil {
-		attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, nil)
-		rec := attendanceService.ComputeData(
+		rec := s.services.attendance.ComputeData(
 			staffmodels.StaffRowBase(staff),
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
@@ -400,8 +398,7 @@ func (s *Server) adminStaffAttendanceRowsHandler(w http.ResponseWriter, r *http.
 	attendance, err := s.services.staff.GetAttendanceByDate(ctx, staff.ID, date)
 	var record *models.Attendance
 	if err == nil {
-		attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, nil)
-		rec := attendanceService.ComputeData(
+		rec := s.services.attendance.ComputeData(
 			staffmodels.StaffRowBase(staff),
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
@@ -439,8 +436,7 @@ func (s *Server) adminStaffTimeInHandler(w http.ResponseWriter, r *http.Request)
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	svc := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	err := svc.TimeIn(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
+	err := s.services.attendance.TimeIn(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
 	if err != nil {
 		http.Error(w, "Unable to time in", http.StatusBadRequest)
 		return
@@ -454,8 +450,7 @@ func (s *Server) adminStaffTimeOutHandler(w http.ResponseWriter, r *http.Request
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	svc := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	err := svc.TimeOut(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
+	err := s.services.attendance.TimeOut(ctx, s.sessionManager.GetString(ctx, SessionStaffID), date, now, location, useragentID)
 	if err != nil {
 		http.Error(w, "Unable to time out", http.StatusBadRequest)
 		return
@@ -471,8 +466,7 @@ func (s *Server) adminStaffLunchBreakInHandler(w http.ResponseWriter, r *http.Re
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	svc := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	err := svc.LunchBreakIn(ctx, staffID, date, now, location, useragentID)
+	err := s.services.attendance.LunchBreakIn(ctx, staffID, date, now, location, useragentID)
 	if err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
@@ -494,8 +488,7 @@ func (s *Server) adminStaffLunchBreakOutHandler(w http.ResponseWriter, r *http.R
 	date := utils.NowPH().Format(constants.DateLayoutISO)
 	location := GetLocation(ctx, s.sessionManager)
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	svc := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	err := svc.LunchBreakOut(ctx, staffID, date, now, location, useragentID)
+	err := s.services.attendance.LunchBreakOut(ctx, staffID, date, now, location, useragentID)
 	if err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
@@ -556,8 +549,7 @@ func (s *Server) adminStaffTimeOffHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	useragentID := getOrCreateUserAgentID(ctx, s.dbRW, r.UserAgent())
-	svc := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	if err := svc.TimeOff(
+	if err := s.services.attendance.TimeOff(
 		ctx,
 		s.sessionManager.GetString(ctx, SessionStaffID),
 		timeOffType,

--- a/internal/server/admin_superuser.go
+++ b/internal/server/admin_superuser.go
@@ -14,7 +14,6 @@ import (
 	"cchoice/internal/database/queries"
 	"cchoice/internal/enums"
 	"cchoice/internal/logs"
-	"cchoice/internal/services"
 	staffmodels "cchoice/internal/staff"
 	"cchoice/internal/utils"
 
@@ -57,10 +56,7 @@ func (s *Server) adminSuperuserAttendanceHandler(w http.ResponseWriter, r *http.
 	}
 	endDate := utils.ParseAttendanceDate(endDateParam)
 
-	//TODO: (Brandon) services should be in the Server struct as well
-	//                see how I implemented ProductsService in server
-	attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	attendances, err := attendanceService.GetAttendance(ctx, r.FormValue("staff-id"), startDate, endDate)
+	attendances, err := s.services.attendance.GetAttendance(ctx, r.FormValue("staff-id"), startDate, endDate)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("start date", startDateParam), zap.String("end date", endDateParam))
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -85,7 +81,7 @@ func (s *Server) adminSuperuserAttendanceHandler(w http.ResponseWriter, r *http.
 		}
 		attendanceData = append(
 			attendanceData,
-			attendanceService.ComputeData(staffmodels.StaffRowBase(staff), att),
+			s.services.attendance.ComputeData(staffmodels.StaffRowBase(staff), att),
 		)
 	}
 
@@ -133,8 +129,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 	}
 
 	staffID := r.FormValue("staff-id")
-	attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	attendances, err := attendanceService.GetAttendance(ctx, staffID, startDate, endDate)
+	attendances, err := s.services.attendance.GetAttendance(ctx, staffID, startDate, endDate)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
 		redirectHX(w, r, utils.URLWithError(page, err.Error()))
@@ -157,14 +152,13 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 		zap.String("param staff id", staffID),
 	)
 
-	reportService := services.NewReportService(s.encoder, s.dbRO)
 	switch format {
 	case "csv":
 		w.Header().Set("Content-Type", "text/csv")
 		writer := csv.NewWriter(w)
 		defer writer.Flush()
 
-		if err := reportService.StreamReportCSV(
+		if err := s.services.report.StreamReportCSV(
 			ctx,
 			writer,
 			attendances,
@@ -188,7 +182,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 		file := excelize.NewFile()
 		defer file.Close()
 
-		if err := reportService.StreamReportXLSX(
+		if err := s.services.report.StreamReportXLSX(
 			ctx,
 			file,
 			attendances,
@@ -292,8 +286,7 @@ func (s *Server) adminSuperuserTimeOffApproveHandler(w http.ResponseWriter, r *h
 	}
 
 	timeOffID := chi.URLParam(r, "id")
-	attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	if err := attendanceService.ApproveTimeOff(ctx, timeOffID, currentStaffIDStr); err != nil {
+	if err := s.services.attendance.ApproveTimeOff(ctx, timeOffID, currentStaffIDStr); err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.String("time_off_id", timeOffID), zap.Error(err))
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
@@ -313,8 +306,7 @@ func (s *Server) adminSuperuserTimeOffCancelHandler(w http.ResponseWriter, r *ht
 	}
 
 	timeOffID := chi.URLParam(r, "id")
-	attendanceService := services.NewAttendanceService(s.encoder, s.dbRO, s.dbRW)
-	if err := attendanceService.CancelTimeOff(ctx, timeOffID); err != nil {
+	if err := s.services.attendance.CancelTimeOff(ctx, timeOffID); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
 			zap.String("time_off_id", timeOffID),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,8 @@ type Services struct {
 	staffLog     *services.StaffLogsService
 	role         *services.RoleService
 	location     *services.LocationService
+	attendance   *services.AttendanceService
+	report       *services.ReportService
 }
 
 type Server struct {
@@ -154,6 +156,8 @@ func NewServer() *ServerInstance {
 		staffLog:     services.NewStaffLogsService(newServer.encoder, newServer.dbRO, newServer.dbRW),
 		role:         services.NewRoleService(newServer.encoder, newServer.dbRO, newServer.dbRW),
 		location:     services.NewLocationService(cfg.Settings.ShopLocation),
+		attendance:   services.NewAttendanceService(newServer.encoder, newServer.dbRO, newServer.dbRW),
+		report:       services.NewReportService(newServer.encoder, newServer.dbRO),
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
## Describe your changes
Have resolved a TODO by centralizing `AttendanceService` and `ReportService` into the shared `Server` struct. This prevents unnecessary per-request memory allocations in `admin_superuser.go` and `admin_staff.go`, aligning their implementation with the existing ProductsService pattern.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
<img width="1919" height="1005" alt="image" src="https://github.com/user-attachments/assets/6c995011-f8a7-4b61-834c-dc6fa65bdeda" />
