### PR TITLE
Maintenance: Add audit logging for report exports

### DIFF
--- a/internal/server/admin_superuser.go
+++ b/internal/server/admin_superuser.go
@@ -130,6 +130,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 	}
 
 	staffID := r.FormValue("staff-id")
+	adminStaffID := s.sessionManager.GetString(ctx, SessionStaffID)
 	attendances, err := s.services.attendance.GetAttendance(ctx, staffID, startDate, endDate)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
@@ -149,7 +150,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 		zap.String("file", reportName),
 		zap.String("start date", startDate),
 		zap.String("end date", endDate),
-		zap.String("staff id", s.sessionManager.GetString(ctx, SessionStaffID)),
+		zap.String("staff id", adminStaffID),
 		zap.String("param staff id", staffID),
 	)
 
@@ -163,6 +164,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 			ctx,
 			writer,
 			attendances,
+			adminStaffID,
 			staffID,
 			reportName,
 			startDate,
@@ -187,6 +189,7 @@ func (s *Server) adminSuperuserAttendanceReportHandler(w http.ResponseWriter, r 
 			ctx,
 			file,
 			attendances,
+			adminStaffID,
 			staffID,
 			reportName,
 			startDate,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,16 +158,18 @@ func NewServer() *ServerInstance {
 		useSSL:             cfg.Server.UseSSL,
 	}
 
+	staffLogService := services.NewStaffLogsService(newServer.encoder, newServer.dbRO, newServer.dbRW)
+
 	newServer.services = Services{
 		product:      services.NewProductService(newServer.encoder, newServer.dbRO, newServer.dbRW, newServer.GetCDNURL),
 		productImage: services.NewProductImageService(newServer.objectStorage, newServer.encoder, newServer.dbRO, newServer.dbRW),
 		brand:        services.NewBrandService(newServer.encoder, newServer.dbRO, newServer.dbRW),
 		staff:        services.NewStaffService(newServer.encoder, newServer.dbRO, newServer.dbRW),
-		staffLog:     services.NewStaffLogsService(newServer.encoder, newServer.dbRO, newServer.dbRW),
+		staffLog:     staffLogService,
 		role:         services.NewRoleService(newServer.encoder, newServer.dbRO, newServer.dbRW),
 		location:     services.NewLocationService(cfg.Settings.ShopLocation),
 		attendance:   services.NewAttendanceService(newServer.encoder, newServer.dbRO, newServer.dbRW),
-		report:       services.NewReportService(newServer.encoder, newServer.dbRO),
+		report:       services.NewReportService(newServer.encoder, newServer.dbRO, staffLogService),
 		customer:     services.NewCustomerService(newServer.encoder, newServer.dbRO, newServer.dbRW),
 	}
 

--- a/internal/services/report.go
+++ b/internal/services/report.go
@@ -18,17 +18,23 @@ import (
 )
 
 type ReportService struct {
-	encoder encode.IEncode
-	dbRO    database.IService
+	encoder  encode.IEncode
+	dbRO     database.IService
+	staffLog *StaffLogsService
 }
 
 func NewReportService(
 	encoder encode.IEncode,
 	dbRO database.IService,
+	staffLog *StaffLogsService,
 ) *ReportService {
+	if staffLog == nil {
+		panic("staffLog service is required")
+	}
 	return &ReportService{
-		encoder: encoder,
-		dbRO:    dbRO,
+		encoder:  encoder,
+		dbRO:     dbRO,
+		staffLog: staffLog,
 	}
 }
 
@@ -36,18 +42,29 @@ func (s *ReportService) StreamReportCSV(
 	ctx context.Context,
 	writer *csv.Writer,
 	data []staff.StaffRow,
+	adminStaffID string,
 	staffID string,
 	filename string,
 	startDate string,
 	endDate string,
 ) error {
+	result := "success"
+	defer func() {
+		if err := s.staffLog.CreateLog(ctx, adminStaffID, "export", "attendance_report_csv", result, nil); err != nil {
+			logs.LogCtx(ctx).Error("[ReportService] failed to log csv report generation", zap.Error(err))
+		}
+	}()
+
 	if err := writer.Write([]string{"Report name: " + filename}); err != nil {
+		result = err.Error()
 		return err
 	}
 	if err := writer.Write([]string{"Start date: " + startDate}); err != nil {
+		result = err.Error()
 		return err
 	}
 	if err := writer.Write([]string{"End date: " + endDate}); err != nil {
+		result = err.Error()
 		return err
 	}
 
@@ -55,14 +72,17 @@ func (s *ReportService) StreamReportCSV(
 	if decodedStaffID != encode.INVALID {
 		totalDays, err := utils.GetTotalDaysBetweenDates(startDate, endDate)
 		if err != nil {
+			result = err.Error()
 			return err
 		}
 		if err := writer.Write([]string{fmt.Sprintf("Total days (present/total): %d/%d", len(data), totalDays)}); err != nil {
+			result = err.Error()
 			return err
 		}
 
 		staffDB, err := s.dbRO.GetQueries().GetStaffByID(ctx, decodedStaffID)
 		if err != nil {
+			result = err.Error()
 			return err
 		}
 		if err := writer.Write([]string{fmt.Sprintf(
@@ -70,6 +90,7 @@ func (s *ReportService) StreamReportCSV(
 			staffDB.TimeInSchedule.String,
 			staffDB.TimeOutSchedule.String,
 		)}); err != nil {
+			result = err.Error()
 			return err
 		}
 
@@ -173,25 +194,36 @@ func (s *ReportService) StreamReportXLSX(
 	ctx context.Context,
 	file *excelize.File,
 	data []staff.StaffRow,
+	adminStaffID string,
 	staffID string,
 	filename string,
 	startDate string,
 	endDate string,
 ) error {
+	result := "success"
+	defer func() {
+		if err := s.staffLog.CreateLog(ctx, adminStaffID, "export", "attendance_report_xlsx", result, nil); err != nil {
+			logs.LogCtx(ctx).Error("[ReportService] failed to log xlsx report generation", zap.Error(err))
+		}
+	}()
+
 	const sheet = "Sheet1"
 	row := 1
 
 	if err := file.SetCellValue(sheet, fmt.Sprintf("A%d", row), "Report name: "+filename); err != nil {
+		result = err.Error()
 		return err
 	}
 	row++
 
 	if err := file.SetCellValue(sheet, fmt.Sprintf("A%d", row), "Start date: "+startDate); err != nil {
+		result = err.Error()
 		return err
 	}
 	row++
 
 	if err := file.SetCellValue(sheet, fmt.Sprintf("A%d", row), "End date: "+endDate); err != nil {
+		result = err.Error()
 		return err
 	}
 	row++
@@ -359,7 +391,6 @@ func (s *ReportService) StreamReportXLSX(
 		}
 		row++
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Describe your changes
Made `StaffLogsService` a direct dependency of `ReportService` to handle audit logging internally.
Added `adminStaffID` to `StreamReportCSV` and `StreamReportXLSX` to record the exact user generating the reports.
Audit logs for both CSV and XLSX exports are now securely created inside the service methods right before successful completion, instead of relying on the HTTP handlers.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
<img width="1919" height="949" alt="image" src="https://github.com/user-attachments/assets/d9116b10-cbec-4428-a6a1-116f92d87fd8" />
