### PR TITLE
Maintenance: Refactor superuser staff handlers

### DIFF
--- a/cmd/web/models/structs.go
+++ b/cmd/web/models/structs.go
@@ -131,6 +131,7 @@ func ToSearchResultProduct[T queries.GetProductsBySearchQueryRow](
 }
 
 type AdminStaffProfile struct {
+	ID               int64
 	FullName         string
 	FirstName        string
 	MiddleName       string

--- a/internal/server/admin_staff.go
+++ b/internal/server/admin_staff.go
@@ -26,17 +26,17 @@ func (s *Server) adminStaffHomeHandler(w http.ResponseWriter, r *http.Request) {
 	staffIDStr := s.sessionManager.GetString(ctx, SessionStaffID)
 	staff, err := s.services.staff.GetCurrentStaff(ctx, staffIDStr)
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Int64("staff_id", staff.ID), zap.Error(err))
+		logs.LogCtx(ctx).Error(logtag, zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)), zap.Error(err))
 		redirectHXLogin(w, r)
 		return
 	}
 
 	roles, err := s.services.role.GetByStaffID(ctx, staffIDStr)
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Int64("staff_id", staff.ID), zap.Error(err))
+		logs.LogCtx(ctx).Error(logtag, zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)), zap.Error(err))
 	}
 
-	currentUserFullName := utils.BuildFullName(staff.FirstName, staff.MiddleName.String, staff.LastName)
+	currentUserFullName := staff.FullName
 	if err := compadmin.AdminStaffHomePage(currentUserFullName, roles).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
@@ -53,12 +53,12 @@ func (s *Server) adminStaffProfileHandler(w http.ResponseWriter, r *http.Request
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
 
-	profile := s.services.staff.BuildProfile(staff)
+	profile := staff
 
 	if err := compadmin.AdminProfilePage(profile).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
@@ -77,12 +77,12 @@ func (s *Server) adminStaffProfileHeaderHandler(w http.ResponseWriter, r *http.R
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
 
-	profile := s.services.staff.BuildProfile(staff)
+	profile := staff
 
 	if err := compadmin.AdminProfileHeader(profile).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
@@ -139,18 +139,18 @@ func (s *Server) adminProfileEditFormHandler(w http.ResponseWriter, r *http.Requ
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
 
-	profile := s.services.staff.BuildProfile(staff)
+	profile := staff
 
 	if err := compadmin.AdminProfileEditForm(profile).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
 			zap.String("path", r.URL.Path),
-			zap.Int64("staff_id", staff.ID),
+			zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)),
 			zap.Error(err),
 		)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -204,17 +204,17 @@ func (s *Server) adminStaffListHandler(w http.ResponseWriter, r *http.Request) {
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
 
 	var list []models.Staff
-	switch enums.ParseStaffUserTypeToEnum(staff.UserType) {
+	switch staff.UserType {
 	case enums.STAFF_USER_TYPE_STAFF:
 		list = append(list, models.Staff{
 			ID:       s.encoder.Encode(staff.ID),
-			FullName: utils.BuildFullName(staff.FirstName, staff.MiddleName.String, staff.LastName),
+			FullName: staff.FullName,
 		})
 	case enums.STAFF_USER_TYPE_SUPERUSER:
 		list, err = s.services.staff.GetAll(ctx, 100)
@@ -233,7 +233,7 @@ func (s *Server) adminStaffPageHandler(w http.ResponseWriter, r *http.Request) {
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
@@ -259,7 +259,13 @@ func (s *Server) adminStaffPageHandler(w http.ResponseWriter, r *http.Request) {
 		hasLunchBreakOut = attendance.LunchBreakOut.Valid
 
 		rec := s.services.attendance.ComputeData(
-			staffmodels.StaffRowBase(staff),
+			staffmodels.StaffRowBase{
+				ID:              staff.ID,
+				FirstName:       staff.FirstName,
+				LastName:        staff.LastName,
+				TimeInSchedule:  sql.NullString{String: staff.ScheduledTimeIn, Valid: staff.ScheduledTimeIn != ""},
+				TimeOutSchedule: sql.NullString{String: staff.ScheduledTimeOut, Valid: staff.ScheduledTimeOut != ""},
+			},
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
 				StaffID:                  staff.ID,
@@ -290,8 +296,8 @@ func (s *Server) adminStaffPageHandler(w http.ResponseWriter, r *http.Request) {
 		attendance.OutLocation,
 	)
 
-	scheduledTimeIn := staff.TimeInSchedule.String
-	scheduledTimeOut := staff.TimeOutSchedule.String
+	scheduledTimeIn := staff.ScheduledTimeIn
+	scheduledTimeOut := staff.ScheduledTimeOut
 
 	canTimeIn := !hasTimeIn
 	canTimeOut := hasTimeIn && !hasTimeOut
@@ -307,7 +313,7 @@ func (s *Server) adminStaffPageHandler(w http.ResponseWriter, r *http.Request) {
 	// }
 
 	locationDisplay, distanceMeters = s.services.location.ComputeLocationDisplay(ctx, s.sessionManager)
-	profile := s.services.staff.BuildProfile(staff)
+	profile := staff
 	profile.ScheduledTimeIn = scheduledTimeIn
 	profile.ScheduledTimeOut = scheduledTimeOut
 	profile.SelectedDate = today
@@ -342,7 +348,7 @@ func (s *Server) adminStaffAttendanceTableHandler(w http.ResponseWriter, r *http
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
@@ -352,7 +358,13 @@ func (s *Server) adminStaffAttendanceTableHandler(w http.ResponseWriter, r *http
 	var record *models.Attendance
 	if err == nil {
 		rec := s.services.attendance.ComputeData(
-			staffmodels.StaffRowBase(staff),
+			staffmodels.StaffRowBase{
+				ID:              staff.ID,
+				FirstName:       staff.FirstName,
+				LastName:        staff.LastName,
+				TimeInSchedule:  sql.NullString{String: staff.ScheduledTimeIn, Valid: staff.ScheduledTimeIn != ""},
+				TimeOutSchedule: sql.NullString{String: staff.ScheduledTimeOut, Valid: staff.ScheduledTimeOut != ""},
+			},
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
 				StaffID:                  staff.ID,
@@ -389,7 +401,7 @@ func (s *Server) adminStaffAttendanceRowsHandler(w http.ResponseWriter, r *http.
 
 	staff, err := s.services.staff.GetCurrentStaff(ctx, s.sessionManager.GetString(ctx, SessionStaffID))
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.Int64("staff_id", staff.ID))
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("staff_id", s.sessionManager.GetString(ctx, SessionStaffID)))
 		redirectHXLogin(w, r)
 		return
 	}
@@ -399,7 +411,13 @@ func (s *Server) adminStaffAttendanceRowsHandler(w http.ResponseWriter, r *http.
 	var record *models.Attendance
 	if err == nil {
 		rec := s.services.attendance.ComputeData(
-			staffmodels.StaffRowBase(staff),
+			staffmodels.StaffRowBase{
+				ID:              staff.ID,
+				FirstName:       staff.FirstName,
+				LastName:        staff.LastName,
+				TimeInSchedule:  sql.NullString{String: staff.ScheduledTimeIn, Valid: staff.ScheduledTimeIn != ""},
+				TimeOutSchedule: sql.NullString{String: staff.ScheduledTimeOut, Valid: staff.ScheduledTimeOut != ""},
+			},
 			staffmodels.StaffRow{
 				ID:                       staff.ID,
 				StaffID:                  staff.ID,
@@ -605,7 +623,7 @@ func (s *Server) adminStaffAttendanceLocationHandler(w http.ResponseWriter, r *h
 
 	locationResult := s.services.location.ComputeLocation(attendanceLocation, GetLocation(ctx, s.sessionManager))
 
-	profile := s.services.staff.BuildProfile(staff)
+	profile := staff
 	profile.InShop = locationResult.InShop
 	profile.LocationDisplay = locationResult.LocationDisplay
 	profile.DistanceMeters = locationResult.DistanceMeters

--- a/internal/server/admin_superuser.go
+++ b/internal/server/admin_superuser.go
@@ -11,11 +11,9 @@ import (
 
 	compadmin "cchoice/cmd/web/components/admin"
 	"cchoice/cmd/web/models"
-	"cchoice/internal/constants"
 	"cchoice/internal/database/queries"
 	"cchoice/internal/enums"
 	"cchoice/internal/logs"
-	staffmodels "cchoice/internal/staff"
 	"cchoice/internal/utils"
 
 	"go.uber.org/zap"
@@ -28,11 +26,11 @@ func (s *Server) adminSuperuserHomeHandler(w http.ResponseWriter, r *http.Reques
 	staffIDStr := s.sessionManager.GetString(ctx, SessionStaffID)
 	staff, err := s.services.staff.GetCurrentStaff(ctx, staffIDStr)
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Int64("staff_id", staff.ID), zap.Error(err))
+		logs.LogCtx(ctx).Error(logtag, zap.String("staff_id", staffIDStr), zap.Error(err))
 		redirectHXLogin(w, r)
 		return
 	}
-	currentUserFullName := utils.BuildFullName(staff.FirstName, staff.MiddleName.String, staff.LastName)
+	currentUserFullName := staff.FullName
 
 	if err := compadmin.AdminSuperuserHomePage(currentUserFullName).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
@@ -63,28 +61,13 @@ func (s *Server) adminSuperuserAttendanceHandler(w http.ResponseWriter, r *http.
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
 
-	staffs, err := s.dbRO.GetQueries().GetAllStaffs(ctx, maxStaffListSize)
+	staffs, err := s.services.staff.GetAllStaffsRow(ctx, maxStaffListSize)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
 		staffs = []queries.GetAllStaffsRow{}
 	}
 
-	staffMap := make(map[int64]queries.GetAllStaffsRow)
-	for _, staff := range staffs {
-		staffMap[staff.ID] = staff
-	}
-
-	attendanceData := make([]models.Attendance, 0, len(attendances))
-	for _, att := range attendances {
-		staff, ok := staffMap[att.StaffID]
-		if !ok {
-			continue
-		}
-		attendanceData = append(
-			attendanceData,
-			s.services.attendance.ComputeData(staffmodels.StaffRowBase(staff), att),
-		)
-	}
+	attendanceData := s.services.attendance.ComputeAllAttendanceData(staffs, attendances)
 
 	if err := compadmin.AdminSuperuserAttendanceTable(attendanceData).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.String("path", r.URL.Path), zap.Error(err))
@@ -220,52 +203,10 @@ func (s *Server) adminSuperuserTimeOffTableHandler(w http.ResponseWriter, r *htt
 	const logtag = "[Admin Superuser Time Off Table Handler]"
 	ctx := r.Context()
 
-	timeOffs, err := s.dbRO.GetQueries().GetAllStaffTimeOffs(ctx)
+	staffTimeOffs, err := s.services.attendance.GetAllStaffTimeOffs(ctx)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
-		timeOffs = []queries.GetAllStaffTimeOffsRow{}
-	}
-
-	staffTimeOffs := make([]models.StaffTimeOff, 0, len(timeOffs))
-	for _, to := range timeOffs {
-		var approvedBy string
-		var approvedAt string
-
-		if to.ApprovedBy.Valid && to.ApproverFirstName.Valid {
-			approvedBy = utils.BuildFullName(
-				to.ApproverFirstName.String,
-				to.ApproverMiddleName.String,
-				to.ApproverLastName.String,
-			)
-		} else {
-			approvedBy = "-"
-		}
-
-		if to.ApprovedAt.Valid {
-			approvedAt = to.ApprovedAt.Time.Format(constants.DateTimeLayoutISO)
-		} else {
-			approvedAt = "-"
-		}
-
-		fullName := utils.BuildFullName(
-			to.StaffFirstName,
-			to.StaffMiddleName.String,
-			to.StaffLastName,
-		)
-
-		staffTimeOffs = append(staffTimeOffs, models.StaffTimeOff{
-			ID:          s.encoder.Encode(to.ID),
-			StaffID:     s.encoder.Encode(to.StaffID),
-			FullName:    fullName,
-			Type:        enums.ParseTimeOffToEnum(to.Type),
-			CreatedAt:   utils.ConvertToPH(to.CreatedAt),
-			StartDate:   to.StartDate.Format(constants.DateLayoutISO),
-			EndDate:     to.EndDate.Format(constants.DateLayoutISO),
-			Description: to.Description,
-			Approved:    to.Approved.Bool,
-			ApprovedBy:  approvedBy,
-			ApprovedAt:  approvedAt,
-		})
+		staffTimeOffs = []models.StaffTimeOff{}
 	}
 
 	if err := compadmin.AdminSuperuserTimeOffTable(staffTimeOffs).Render(ctx, w); err != nil {
@@ -279,9 +220,9 @@ func (s *Server) adminSuperuserTimeOffApproveHandler(w http.ResponseWriter, r *h
 	const logtag = "[Admin Superuser Time Off Approve Handler]"
 	ctx := r.Context()
 	currentStaffIDStr := s.sessionManager.GetString(ctx, SessionStaffID)
-	staff, err := s.services.staff.GetCurrentStaff(ctx, currentStaffIDStr)
+	_, err := s.services.staff.GetCurrentStaff(ctx, currentStaffIDStr)
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Int64("staff_id", staff.ID), zap.Error(err))
+		logs.LogCtx(ctx).Error(logtag, zap.String("staff_id", currentStaffIDStr), zap.Error(err))
 		redirectHXLogin(w, r)
 		return
 	}
@@ -299,9 +240,9 @@ func (s *Server) adminSuperuserTimeOffCancelHandler(w http.ResponseWriter, r *ht
 	const logtag = "[Admin Superuser Time Off Cancel Handler]"
 	ctx := r.Context()
 	currentStaffIDStr := s.sessionManager.GetString(ctx, SessionStaffID)
-	staff, err := s.services.staff.GetCurrentStaff(ctx, currentStaffIDStr)
+	_, err := s.services.staff.GetCurrentStaff(ctx, currentStaffIDStr)
 	if err != nil {
-		logs.LogCtx(ctx).Error(logtag, zap.Int64("staff_id", staff.ID), zap.Error(err))
+		logs.LogCtx(ctx).Error(logtag, zap.String("staff_id", currentStaffIDStr), zap.Error(err))
 		redirectHXLogin(w, r)
 		return
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -131,12 +131,12 @@ func (s *Server) requireStaffAuth(next http.Handler) http.Handler {
 func (s *Server) requireSuperuserAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		staff, err := s.services.staff.GetCurrentStaff(r.Context(), s.sessionManager.GetString(r.Context(), SessionStaffID))
-		if staff.ID == 0 {
+		if err != nil || staff.ID == 0 {
 			http.Redirect(w, r, utils.URL("/admin"), http.StatusSeeOther)
 			return
 		}
 
-		if err != nil || staff.UserType != enums.STAFF_USER_TYPE_SUPERUSER.String() {
+		if staff.UserType != enums.STAFF_USER_TYPE_SUPERUSER {
 			http.Redirect(w, r, utils.URL("/admin/staff"), http.StatusSeeOther)
 			return
 		}
@@ -160,7 +160,7 @@ func (s *Server) HasRole(ctx context.Context, role enums.StaffRole) bool {
 		return false
 	}
 
-	if staff.UserType == enums.STAFF_USER_TYPE_SUPERUSER.String() {
+	if staff.UserType == enums.STAFF_USER_TYPE_SUPERUSER {
 		return true
 	}
 

--- a/internal/services/attendance.go
+++ b/internal/services/attendance.go
@@ -523,3 +523,74 @@ func (s *AttendanceService) GetExtraStats(ctx context.Context, staffID string, d
 	}
 	return res
 }
+
+func (s *AttendanceService) ComputeAllAttendanceData(staffs []queries.GetAllStaffsRow, attendances []staff.StaffRow) []models.Attendance {
+	staffMap := make(map[int64]queries.GetAllStaffsRow)
+	for _, staff := range staffs {
+		staffMap[staff.ID] = staff
+	}
+
+	attendanceData := make([]models.Attendance, 0, len(attendances))
+	for _, att := range attendances {
+		st, ok := staffMap[att.StaffID]
+		if !ok {
+			continue
+		}
+		attendanceData = append(
+			attendanceData,
+			s.ComputeData(staff.StaffRowBase(st), att),
+		)
+	}
+	return attendanceData
+}
+
+func (s *AttendanceService) GetAllStaffTimeOffs(ctx context.Context) ([]models.StaffTimeOff, error) {
+	timeOffs, err := s.dbRO.GetQueries().GetAllStaffTimeOffs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	staffTimeOffs := make([]models.StaffTimeOff, 0, len(timeOffs))
+	for _, to := range timeOffs {
+		var approvedBy string
+		var approvedAt string
+
+		if to.ApprovedBy.Valid && to.ApproverFirstName.Valid {
+			approvedBy = utils.BuildFullName(
+				to.ApproverFirstName.String,
+				to.ApproverMiddleName.String,
+				to.ApproverLastName.String,
+			)
+		} else {
+			approvedBy = "-"
+		}
+
+		if to.ApprovedAt.Valid {
+			approvedAt = to.ApprovedAt.Time.Format(constants.DateTimeLayoutISO)
+		} else {
+			approvedAt = "-"
+		}
+
+		fullName := utils.BuildFullName(
+			to.StaffFirstName,
+			to.StaffMiddleName.String,
+			to.StaffLastName,
+		)
+
+		staffTimeOffs = append(staffTimeOffs, models.StaffTimeOff{
+			ID:          s.encoder.Encode(to.ID),
+			StaffID:     s.encoder.Encode(to.StaffID),
+			FullName:    fullName,
+			Type:        enums.ParseTimeOffToEnum(to.Type),
+			CreatedAt:   utils.ConvertToPH(to.CreatedAt),
+			StartDate:   to.StartDate.Format(constants.DateLayoutISO),
+			EndDate:     to.EndDate.Format(constants.DateLayoutISO),
+			Description: to.Description,
+			Approved:    to.Approved.Bool,
+			ApprovedBy:  approvedBy,
+			ApprovedAt:  approvedAt,
+		})
+	}
+
+	return staffTimeOffs, nil
+}

--- a/internal/services/staff.go
+++ b/internal/services/staff.go
@@ -114,14 +114,22 @@ func (s *StaffService) GetAllForAdmin(ctx context.Context, search string) ([]que
 	return s.dbRO.GetQueries().GetAllStaffsForAdmin(ctx, search)
 }
 
-func (s *StaffService) GetCurrentStaff(ctx context.Context, staffID string) (queries.GetStaffByIDRow, error) {
+func (s *StaffService) GetAllStaffsRow(ctx context.Context, limit int64) ([]queries.GetAllStaffsRow, error) {
+	return s.dbRO.GetQueries().GetAllStaffs(ctx, limit)
+}
+
+func (s *StaffService) GetCurrentStaff(ctx context.Context, staffID string) (models.AdminStaffProfile, error) {
 	decodedID := s.encoder.Decode(staffID)
 	staff, err := s.dbRO.GetQueries().GetStaffByID(ctx, decodedID)
-	return staff, err
+	if err != nil {
+		return models.AdminStaffProfile{}, err
+	}
+	return s.BuildProfile(staff), nil
 }
 
 func (s *StaffService) BuildProfile(staff queries.GetStaffByIDRow) models.AdminStaffProfile {
 	return models.AdminStaffProfile{
+		ID:               staff.ID,
 		FullName:         utils.BuildFullName(staff.FirstName, staff.MiddleName.String, staff.LastName),
 		FirstName:        staff.FirstName,
 		MiddleName:       staff.MiddleName.String,


### PR DESCRIPTION
## Describe your changes
Updated `GetCurrentStaff` to return `models.AdminStaffProfile` instead of a raw database row, centralizing profile construction.
Replaced `staff.ID` int64 usages with the string session ID across admin and middleware handlers since the profile model abstracts the raw DB row.
Extracted the complex attendance mapping loop into a new `AttendanceService.ComputeAllAttendanceData` method.
Moved the time-off data formatting logic out of the handler into a new `AttendanceService.GetAllStaffTimeOffs` method.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
https://drive.google.com/file/d/1l6MQhOUxyVv6O1X6fRp0TcEAFjV7aI3q/view?usp=sharing