### PR TITLE
Maintenance: Address static analysis reports

### DIFF
--- a/cmd/parse_products.go
+++ b/cmd/parse_products.go
@@ -240,10 +240,8 @@ var cmdParseProducts = &cobra.Command{
 		for start, end := 0, 0; start <= len(products)-1; start = end {
 			end = min(start+batchsize, len(products))
 			batch := products[start:end]
-			wg.Add(1)
 
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for _, product := range batch {
 					existingProductId := product.GetDBID(cmd.Context(), tpl.CtxApp.DB)
 					if existingProductId != 0 {
@@ -300,7 +298,7 @@ var cmdParseProducts = &cobra.Command{
 						}
 					}
 				}
-			}()
+			})
 		}
 		wg.Wait()
 		tpl.CtxApp.Metrics.Add("Get product IDS (parallel)", time.Since(startWG))

--- a/cmd/scan_receipt.go
+++ b/cmd/scan_receipt.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -113,8 +114,8 @@ func parseOutputFormats() []string {
 	formats := []string{}
 
 	if scanOutputFmt != "" {
-		parts := strings.Split(scanOutputFmt, ",")
-		for _, part := range parts {
+		parts := strings.SplitSeq(scanOutputFmt, ",")
+		for part := range parts {
 			format := strings.TrimSpace(strings.ToLower(part))
 			if format == "csv" || format == "json" {
 				formats = append(formats, format)
@@ -156,10 +157,5 @@ func writeOutput(data *scanner.ReceiptData, format string) error {
 }
 
 func contains(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, value)
 }

--- a/cmd/scan_receipt.go
+++ b/cmd/scan_receipt.go
@@ -123,10 +123,10 @@ func parseOutputFormats() []string {
 		}
 	}
 
-	if scanCSV && !contains(formats, "csv") {
+	if scanCSV && !slices.Contains(formats, "csv") {
 		formats = append(formats, "csv")
 	}
-	if scanJSON && !contains(formats, "json") {
+	if scanJSON && !slices.Contains(formats, "json") {
 		formats = append(formats, "json")
 	}
 
@@ -154,8 +154,4 @@ func writeOutput(data *scanner.ReceiptData, format string) error {
 	default:
 		return fmt.Errorf("%w: %s", errs.ErrReceiptInvalidFormat, format)
 	}
-}
-
-func contains(slice []string, value string) bool {
-	return slices.Contains(slice, value)
 }

--- a/internal/mail/maileroo/maileroo.go
+++ b/internal/mail/maileroo/maileroo.go
@@ -99,9 +99,9 @@ func (m *Maileroo) sendEmail(ctx context.Context, to string, cc []string, subjec
 	}
 
 	if isHTML {
-		emailData.HTML = maileroo.StrPtr(body)
+		emailData.HTML = new(body)
 	} else {
-		emailData.Plain = maileroo.StrPtr(body)
+		emailData.Plain = new(body)
 	}
 
 	referenceID, err := m.client.SendBasicEmail(ctx, emailData)

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -103,16 +103,14 @@ func TestConcurrentAccess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 50 {
 				req := httptest.NewRequest(http.MethodPost, "/customer/login", nil)
 				req.RemoteAddr = "192.168.1.1:1234"
 				w := httptest.NewRecorder()
 				middleware.ServeHTTP(w, req)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/requests/homepage.go
+++ b/internal/requests/homepage.go
@@ -7,6 +7,7 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -460,13 +461,7 @@ func GetCategoriesForAdmin(
 			categories[cat] = []string{}
 		}
 		if subcat != "" {
-			hasSubcat := false
-			for _, s := range categories[cat] {
-				if s == subcat {
-					hasSubcat = true
-					break
-				}
-			}
+			hasSubcat := slices.Contains(categories[cat], subcat)
 			if !hasSubcat {
 				categories[cat] = append(categories[cat], subcat)
 			}

--- a/internal/server/admin_cpoints.go
+++ b/internal/server/admin_cpoints.go
@@ -73,8 +73,8 @@ func (s *Server) adminCPointsGeneratePostHandler(w http.ResponseWriter, r *http.
 
 	var productSkus []string
 	if productSkusStr != "" {
-		parts := strings.Split(productSkusStr, ",")
-		for _, part := range parts {
+		parts := strings.SplitSeq(productSkusStr, ",")
+		for part := range parts {
 			sku := strings.TrimSpace(part)
 			if sku != "" {
 				productSkus = append(productSkus, sku)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -182,12 +183,7 @@ func (s *Server) HasRole(ctx context.Context, role enums.StaffRole) bool {
 	}
 
 	roleStr := role.String()
-	for _, r := range roles {
-		if r == roleStr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(roles, roleStr)
 }
 
 func (s *Server) AllowRoles(roles ...enums.StaffRole) func(http.Handler) http.Handler {

--- a/internal/utils/forms.go
+++ b/internal/utils/forms.go
@@ -22,8 +22,7 @@ func FormToStruct(r *http.Request, dst any) error {
 	}
 
 	sliceFields := map[string]struct{}{}
-	for i := 0; i < elem.NumField(); i++ {
-		f := elem.Field(i)
+	for f := range elem.Fields() {
 		if f.Type.Kind() == reflect.Slice {
 			if tag := f.Tag.Get("json"); tag != "" {
 				sliceFields[tag] = struct{}{}


### PR DESCRIPTION
## Describe your changes
Replaced manual `for` loops used for existence-checking with the standard library's `slices.Contains` in `homepage.go`, `middleware.go`, and `scan_receipt.go`.
Updated `strings.Split` to use `strings.SplitSeq` for more efficient iteration without allocating a full slice in `admin_cpoints.go` and `scan_receipt.go`.
Replaced manual `wg.Add(1)` and `defer wg.Done()` patterns with the cleaner `errgroup.Go` or `WaitGroup.Go` methods in `parse_products.go` and `ratelimit_test.go`.
Modernized struct field iteration in `forms.go` by utilizing the new `Type.Fields()` iterator instead of the older `NumField()` / `Field(i)` pattern.
Replaced unnecessary pointer-helper function calls (`StrPtr`) with direct pointer references (`&x` or `new(x)`) in the Maileroo SDK integration.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
<img width="1919" height="446" alt="Screenshot 2026-04-13 141230" src="https://github.com/user-attachments/assets/f2f6ba4c-71b9-46ea-bcac-6337ff8c240c" />
