### PR TITLE
Bugfix: Include superusers in staff list dropdown

### DIFF
--- a/internal/database/queries/staff.sql.go
+++ b/internal/database/queries/staff.sql.go
@@ -302,7 +302,7 @@ SELECT
     created_at,
     updated_at
 FROM tbl_staffs
-WHERE deleted_at = '1970-01-01 00:00:00+00:00' AND user_type = 'STAFF'
+WHERE deleted_at = '1970-01-01 00:00:00+00:00'
 ORDER BY last_name ASC, first_name ASC
 LIMIT ?
 `

--- a/internal/database/sql/staff.sql
+++ b/internal/database/sql/staff.sql
@@ -66,7 +66,7 @@ SELECT
     created_at,
     updated_at
 FROM tbl_staffs
-WHERE deleted_at = '1970-01-01 00:00:00+00:00' AND user_type = 'STAFF'
+WHERE deleted_at = '1970-01-01 00:00:00+00:00'
 ORDER BY last_name ASC, first_name ASC
 LIMIT ?;
 


### PR DESCRIPTION
## Describe your changes
`internal/database/sql/staff.sql` - Remove AND user_type = 'STAFF' from the GetAllStaffs query so it returns both STAFF and SUPERUSER types.
## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
<img width="1919" height="1079" alt="0670eff6-7a1d-4482-86fd-c842a9347577" src="https://github.com/user-attachments/assets/ef78e0af-36ca-4ce6-a4c3-04f9e17785a8" />
