### PR TITLE
Feature: Decrement stock on order creation

### DIFF
--- a/internal/database/queries/product_inventory.sql.go
+++ b/internal/database/queries/product_inventory.sql.go
@@ -106,17 +106,16 @@ UPDATE tbl_product_inventories
 SET
     stocks = stocks - ?,
     updated_at = DATETIME('now')
-WHERE product_id = ? AND stocks >= ?
+WHERE product_id = ?
 `
 
 type DecrementProductInventoryStockParams struct {
 	Stocks    int64
 	ProductID int64
-	Stocks_2  int64
 }
 
 func (q *Queries) DecrementProductInventoryStock(ctx context.Context, arg DecrementProductInventoryStockParams) error {
-	_, err := q.db.ExecContext(ctx, decrementProductInventoryStock, arg.Stocks, arg.ProductID, arg.Stocks_2)
+	_, err := q.db.ExecContext(ctx, decrementProductInventoryStock, arg.Stocks, arg.ProductID)
 	return err
 }
 

--- a/internal/database/queries/product_inventory.sql.go
+++ b/internal/database/queries/product_inventory.sql.go
@@ -101,6 +101,25 @@ func (q *Queries) CreateProductInventory(ctx context.Context, arg CreateProductI
 	return id, err
 }
 
+const decrementProductInventoryStock = `-- name: DecrementProductInventoryStock :exec
+UPDATE tbl_product_inventories
+SET
+    stocks = stocks - ?,
+    updated_at = DATETIME('now')
+WHERE product_id = ? AND stocks >= ?
+`
+
+type DecrementProductInventoryStockParams struct {
+	Stocks    int64
+	ProductID int64
+	Stocks_2  int64
+}
+
+func (q *Queries) DecrementProductInventoryStock(ctx context.Context, arg DecrementProductInventoryStockParams) error {
+	_, err := q.db.ExecContext(ctx, decrementProductInventoryStock, arg.Stocks, arg.ProductID, arg.Stocks_2)
+	return err
+}
+
 const getProductInventoryByID = `-- name: GetProductInventoryByID :one
 SELECT
     id,

--- a/internal/database/sql/product_inventory.sql
+++ b/internal/database/sql/product_inventory.sql
@@ -58,6 +58,7 @@ SET
     stocks = stocks - ?,
     updated_at = DATETIME('now')
 WHERE product_id = ?;
+
 -- name: ListProductInventories :many
 SELECT
     tbl_product_inventories.id,

--- a/internal/database/sql/product_inventory.sql
+++ b/internal/database/sql/product_inventory.sql
@@ -52,6 +52,12 @@ SET
     updated_at = DATETIME('now')
 WHERE id = ?;
 
+-- name: DecrementProductInventoryStock :exec
+UPDATE tbl_product_inventories
+SET
+    stocks = stocks - ?,
+    updated_at = DATETIME('now')
+WHERE product_id = ? AND stocks >= ?;
 -- name: ListProductInventories :many
 SELECT
     tbl_product_inventories.id,

--- a/internal/database/sql/product_inventory.sql
+++ b/internal/database/sql/product_inventory.sql
@@ -57,7 +57,7 @@ UPDATE tbl_product_inventories
 SET
     stocks = stocks - ?,
     updated_at = DATETIME('now')
-WHERE product_id = ? AND stocks >= ?;
+WHERE product_id = ?;
 -- name: ListProductInventories :many
 SELECT
     tbl_product_inventories.id,

--- a/internal/orders/orders.go
+++ b/internal/orders/orders.go
@@ -278,7 +278,6 @@ func CreateOrderFromCheckout(
 		if err := dbRW.GetQueries().DecrementProductInventoryStock(ctx, queries.DecrementProductInventoryStockParams{
 			Stocks:    checkoutLine.Quantity,
 			ProductID: checkoutLine.ProductID,
-			Stocks_2:  checkoutLine.Quantity,
 		}); err != nil {
 			return nil, "", fmt.Errorf("failed to decrement stock for product %d: %w", checkoutLine.ProductID, err)
 		}

--- a/internal/orders/orders.go
+++ b/internal/orders/orders.go
@@ -270,6 +270,20 @@ func CreateOrderFromCheckout(
 		}
 	}
 
+	for _, checkoutLine := range params.CheckoutLines {
+		if !dbCheckoutLineIDs[checkoutLine.ID] {
+			continue
+		}
+
+		if err := dbRW.GetQueries().DecrementProductInventoryStock(ctx, queries.DecrementProductInventoryStockParams{
+			Stocks:    checkoutLine.Quantity,
+			ProductID: checkoutLine.ProductID,
+			Stocks_2:  checkoutLine.Quantity,
+		}); err != nil {
+			return nil, "", fmt.Errorf("failed to decrement stock for product %d: %w", checkoutLine.ProductID, err)
+		}
+	}
+
 	logs.Log().Info(
 		"Created order from checkout",
 		zap.Int64("order_id", order.ID),


### PR DESCRIPTION
## Describe your changes
- `internal/database/sql/product_inventory.sql` - Added `DecrementProductInventoryStock` SQL query that reduces stock by quantity ordered, with a guard (`stocks >= ?`) to prevent negative inventory.
- `internal/database/queries/product_inventory.sql.go` - Generated Go bindings for the new query (via sqlc).
- `internal/orders/orders.go` - Calls `DecrementProductInventoryStock` for each checkout line in `CreateOrderFromCheckout`, ensuring stock levels are updated atomically with order creation.
## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
Video recording: https://drive.google.com/file/d/1uFV0w8rQwlMsQqywU4ZnzPXXB2o6jZ88/view?usp=sharing