### PR TITLE
Bugfix: Fix sale banner click not navigating to product page

### DIFF
--- a/cmd/web/components/shop/promo_product.templ
+++ b/cmd/web/components/shop/promo_product.templ
@@ -2,7 +2,6 @@ package shop
 
 import "cchoice/cmd/web/models"
 import "cchoice/internal/utils"
-import "fmt"
 import "cchoice/cmd/web/components/common"
 
 templ SaleBanner(product models.RandomSaleProduct) {
@@ -32,23 +31,19 @@ templ SaleBanner(product models.RandomSaleProduct) {
 				end
 			"
 	>
-		<div
+		<a
 			id="sale-banner-content"
+			href={ utils.URL("/product/"+product.Slug) }
+			data-promo-product-id={ product.ProductID }
 			class="
 				relative w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto
 				bg-white rounded-2xl shadow-2xl
 				overflow-hidden cursor-pointer
-				transform transition-transform hover:scale-105
+				transform transition-transform hover:scale-105 block
 			"
-			_={ fmt.Sprintf(`
-						on click
-							async call metrics_event('promo_product_click', '%s')
-							go to url '%s'
-						end
-						`,
-						product.ProductID,
-						utils.URL("/product/"+product.ProductID),
-					) }
+			_="on click
+					call metrics_event('promo_product_click', my @data-promo-product-id)
+				end"
 		>
 			<!-- Product Image -->
 			<img
@@ -113,6 +108,6 @@ templ SaleBanner(product models.RandomSaleProduct) {
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 				</svg>
 			</button>
-		</div>
+		</a>
 	</div>
 }

--- a/cmd/web/components/shop/promo_product_templ.go
+++ b/cmd/web/components/shop/promo_product_templ.go
@@ -10,7 +10,6 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import "cchoice/cmd/web/models"
 import "cchoice/internal/utils"
-import "fmt"
 import "cchoice/cmd/web/components/common"
 
 func SaleBanner(product models.RandomSaleProduct) templ.Component {
@@ -41,125 +40,130 @@ func SaleBanner(product models.RandomSaleProduct) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(product.ProductID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 12, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 11, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" class=\"fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm hidden\" _=\"\n\t\t\t\tinit\n\t\t\t\t\tif sessionStorage.getItem('saleBannerShown') !== 'true' then\n\t\t\t\t\t\tremove .hidden from me\n\t\t\t\t\t\tsessionStorage.setItem('saleBannerShown', 'true')\n\t\t\t\t\tend\n\n\t\t\t\t\tset #promo-product-id.value to my @data-product-id\n\t\t\t\tend\n\n\t\t\t\ton click\n\t\t\t\t\tif target is not #sale-banner-content then\n\t\t\t\t\t\tadd .hidden to #sale-banner\n\t\t\t\t\tend\n\t\t\t\tend\n\t\t\t\"><div id=\"sale-banner-content\" class=\"relative w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto bg-white rounded-2xl shadow-2xl overflow-hidden cursor-pointer transform transition-transform hover:scale-105\" _=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" class=\"fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm hidden\" _=\"\n\t\t\t\tinit\n\t\t\t\t\tif sessionStorage.getItem('saleBannerShown') !== 'true' then\n\t\t\t\t\t\tremove .hidden from me\n\t\t\t\t\t\tsessionStorage.setItem('saleBannerShown', 'true')\n\t\t\t\t\tend\n\n\t\t\t\t\tset #promo-product-id.value to my @data-product-id\n\t\t\t\tend\n\n\t\t\t\ton click\n\t\t\t\t\tif target is not #sale-banner-content then\n\t\t\t\t\t\tadd .hidden to #sale-banner\n\t\t\t\t\tend\n\t\t\t\tend\n\t\t\t\"><a id=\"sale-banner-content\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`
-						on click
-							async call metrics_event('promo_product_click', '%s')
-							go to url '%s'
-						end
-						`,
-			product.ProductID,
-			utils.URL("/product/"+product.ProductID),
-		))
+		var templ_7745c5c3_Var3 templ.SafeURL
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/product/" + product.Slug))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 51, Col: 6}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 36, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"><!-- Product Image --><img src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" data-promo-product-id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(product.CDNURL1280)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(product.ProductID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 55, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 37, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" alt=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" class=\"relative w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto bg-white rounded-2xl shadow-2xl overflow-hidden cursor-pointer transform transition-transform hover:scale-105 block\" _=\"on click\n\t\t\t\t\tcall metrics_event('promo_product_click', my @data-promo-product-id)\n\t\t\t\tend\"><!-- Product Image --><img src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(product.Name)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(product.CDNURL1280)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 56, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 50, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" class=\"w-full h-64 object-cover\" loading=\"lazy\"><!-- Product Info --><div class=\"p-6 bg-gradient-to-r from-cchoicesoft to-white\"><div class=\"flex items-center justify-between mb-3\"><div><h3 class=\"text-xl font-bold text-gray-900 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" alt=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(product.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 65, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 51, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</h3><p class=\"text-sm text-gray-600 truncate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" class=\"w-full h-64 object-cover\" loading=\"lazy\"><!-- Product Info --><div class=\"p-6 bg-gradient-to-r from-cchoicesoft to-white\"><div class=\"flex items-center justify-between mb-3\"><div><h3 class=\"text-xl font-bold text-gray-900 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(product.BrandName)
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(product.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 68, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 60, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</p></div><div class=\"bg-red-100 text-red-800 px-3 py-1 rounded-full text-sm font-semibold text-center\">Limited Offer</div></div><div class=\"flex items-center justify-between\"><div><p class=\"text-2xl font-bold text-cchoice\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</h3><p class=\"text-sm text-gray-600 truncate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(product.PriceDisplay)
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(product.BrandName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 78, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 63, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</p><p class=\"text-sm text-gray-500 line-through\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</p></div><div class=\"bg-red-100 text-red-800 px-3 py-1 rounded-full text-sm font-semibold text-center\">Limited Offer</div></div><div class=\"flex items-center justify-between\"><div><p class=\"text-2xl font-bold text-cchoice\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(product.OrigPriceDisplay)
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(product.PriceDisplay)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 81, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 73, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</p></div><div class=\"bg-red-600 text-white px-4 py-2 rounded-full font-bold text-lg shadow-lg\">-")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</p><p class=\"text-sm text-gray-500 line-through\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(product.DiscountPercentage)
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(product.OrigPriceDisplay)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 91, Col: 35}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 76, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</p></div><div class=\"bg-red-600 text-white px-4 py-2 rounded-full font-bold text-lg shadow-lg\">-")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(product.DiscountPercentage)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shop/promo_product.templ`, Line: 86, Col: 35}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -167,7 +171,7 @@ func SaleBanner(product models.RandomSaleProduct) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div><button type=\"button\" class=\"absolute top-2 right-2 bg-white/80 hover:bg-white text-gray-700 hover:text-gray-900 rounded-full p-2 transition-colors backdrop-blur-sm\" aria-label=\"Close banner\" _=\"on click\n\t\t\t\t\t\tadd .hidden to #sale-banner\n\t\t\t\t\t\thalt\n\t\t\t\t\t\"><svg class=\"w-5 h-5\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M6 18L18 6M6 6l12 12\"></path></svg></button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div><button type=\"button\" class=\"absolute top-2 right-2 bg-white/80 hover:bg-white text-gray-700 hover:text-gray-900 rounded-full p-2 transition-colors backdrop-blur-sm\" aria-label=\"Close banner\" _=\"on click\n\t\t\t\t\t\tadd .hidden to #sale-banner\n\t\t\t\t\t\thalt\n\t\t\t\t\t\"><svg class=\"w-5 h-5\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M6 18L18 6M6 6l12 12\"></path></svg></button></a></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/cmd/web/models/homepage.go
+++ b/cmd/web/models/homepage.go
@@ -46,6 +46,7 @@ type HomePageData struct {
 
 type RandomSaleProduct struct {
 	ProductID          string
+	Slug               string
 	CDNURL             string
 	CDNURL1280         string
 	OrigPriceDisplay   string

--- a/internal/database/queries/product.sql.go
+++ b/internal/database/queries/product.sql.go
@@ -932,6 +932,7 @@ func (q *Queries) GetProductsWithoutSlugs(ctx context.Context) ([]GetProductsWit
 const getRandomProductOnSale = `-- name: GetRandomProductOnSale :one
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.name,
 	tbl_products.description,
 	tbl_products.unit_price_with_vat,
@@ -969,6 +970,7 @@ LIMIT 1
 
 type GetRandomProductOnSaleRow struct {
 	ID                       int64
+	Slug                     sql.NullString
 	Name                     string
 	Description              sql.NullString
 	UnitPriceWithVat         int64
@@ -989,6 +991,7 @@ func (q *Queries) GetRandomProductOnSale(ctx context.Context) (GetRandomProductO
 	var i GetRandomProductOnSaleRow
 	err := row.Scan(
 		&i.ID,
+		&i.Slug,
 		&i.Name,
 		&i.Description,
 		&i.UnitPriceWithVat,

--- a/internal/database/sql/product.sql
+++ b/internal/database/sql/product.sql
@@ -243,6 +243,7 @@ LIMIT ?;
 -- name: GetRandomProductOnSale :one
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.name,
 	tbl_products.description,
 	tbl_products.unit_price_with_vat,

--- a/internal/requests/homepage.go
+++ b/internal/requests/homepage.go
@@ -344,6 +344,7 @@ func GetRandomSaleProduct(
 	saleProduct := &models.RandomSaleProduct{
 		GetRandomProductOnSaleRow: product,
 		ProductID:                 encoder.Encode(product.ID),
+		Slug:                      product.Slug.String,
 		CDNURL:                    getCDNURL(product.ThumbnailPath),
 		CDNURL1280:                getCDNURL(constants.ToPath1280(product.ThumbnailPath)),
 		OrigPriceDisplay:          origPrice.Display(),


### PR DESCRIPTION
## Describe your changes
Fixed hyperscript `go to url` being broken by HTML escaping, changed to native `<a>` tag with `href`, and added product `slug` to the sale query so the banner links to the correct text-slug URL.
## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing
Video recording: https://drive.google.com/file/d/1rWkiysjf95zlEQWDRnjEKxkUziU-2pM4/view?usp=sharing