### PR TITLE
Docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,3 +323,28 @@ For `.env` setup, copy `.env.sample` to `.env` and fill in values.
 ---
 
 DO NOT RUN `mage sc` and `mage scf` and `mage dbup` and `mage dbdown`
+
+---
+
+## Cursor Cloud specific instructions
+
+Dependencies (Go tools, `mage`, `goose`, tailwind) are refreshed automatically by the startup update script; system libs (`libvips-dev`, `libmagickwand-dev`, `openslide-tools`, `libxml2-dev`, `libjxl-dev`, `libsqlite3-dev`, `pkg-config`) are baked into the VM snapshot. `mage` lives at `$(go env GOPATH)/bin` (`~/go/bin`), which is on `PATH` in login shells.
+
+### Running the storefront without external secrets (WEB mode)
+- Run in **WEB mode** to exercise the storefront/admin UI without PayMongo/Lalamove/Google Maps/Maileroo credentials. In `LOCAL`/`api` mode those services are `env-required` and the server **panics on boot** (e.g. `[GMAPS]: API key is required`).
+- WEB mode is selected by `APP_ENV` in `.env`. Note: `.air.web.toml` sets `APP_ENV=web`, but `godotenv/autoload` reading `.env` wins, so the value in `.env` is authoritative — set `APP_ENV="web"` there.
+- `.env` also requires (validated even with `USESSL=0`): non-empty `CERTPATH`/`KEYPATH` (dummy paths are fine when `USESSL=0` since certs load only when SSL is on) and **all** `BUSINESS_*` fields non-empty, else boot panics.
+- The app auto-loads `.env` (via `godotenv/autoload`); `goose` also auto-loads `.env`.
+
+### Reliable run vs. hot reload
+- `mage serveweb` starts `templ generate --watch` + tailwind watch + air. On startup the templ watcher rewrites all `*_templ.go` files and **races** air's first build, causing transient `expected 'package', found 'EOF'` failures (large files like `tracked_links_templ.go`). It sometimes recovers on the next file change.
+- For a reliable run, build and run the binary directly: `go build -tags="fts5 staticfs" -o ./tmp/web . && APP_ENV=web ./tmp/web web`. The storefront serves on **http://localhost:2626/cchoice** (port 2626; the `7331` proxy only exists under the templ watcher).
+- The app panics with `open sink "logs/app.log"` if `./logs` is missing. `mage setup` has an early-return that skips creating `logs/` when it also had to create `.env` on the same run — the update script does `mkdir -p logs` to cover this.
+
+### Database & seed data
+- SQLite `test.db`. Apply migrations with the goose binary: `GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING="file:./test.db" GOOSE_MIGRATION_DIR="./migrations/sqlite3" ./tmp/goose up` (per repo policy, migrations are applied manually, never via `mage dbup`).
+- Seed products from the bundled spreadsheet: `go run -tags="fts5 staticfs" ./main.go parse_products -p assets/xlsx/bosch.xlsx -s DATABASE -t BOSCH --use_db --db_path file:./test.db --verify_prices=1 --panic_on_error=1 --images_basepath=./cmd/web/static/images/product_images/bosch/original/ --images_format=webp` (or `mage cleandb`, which also resets the DB).
+- Seed caveats (data, not environment): `parse_products` inserts products with **empty `slug`**, so `/product/{slug}` links 404 (slugs are only generated when products are created via the admin `ProductService`). Product images are referenced as `.webp` but the repo ships `.png` originals, so product/cart thumbnails are blank until `mage genimages` converts them.
+
+### Routes
+- The storefront product catalog is at `/cchoice/` (products lazy-load via HTMX from `/cchoice/product-categories/...`). There is no `/cchoice/shop` route.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Sets up the Cloud Agent development environment for `cchoice` and documents durable, non-obvious run caveats for future agents. The only source change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md` (dependency install/system libs are handled by the VM snapshot + startup update script, not code).

What was set up and verified this session:
- Installed Go tooling (`mage`, pinned `go tool` binaries), built `goose` from the submodule, downloaded the tailwind CLI, and installed native libs (`libvips`, `libmagickwand`, `openslide`, `libxml2`, `libjxl`, `sqlite3` dev).
- Configured `.env` for **WEB mode** (`APP_ENV=web`, dummy cert paths, business fields) so the storefront boots without external PayMongo/Lalamove/Google Maps credentials.
- Applied SQLite migrations to a local `test.db` and seeded 125 BOSCH products.
- Built the app (`mage build` with `fts5,staticfs,imageprocessing`, and the `web` binary), ran unit tests and `go vet`, and ran the storefront end-to-end.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [ ] If it is a core feature, I have added thorough unit/integration tests.
- [ ] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing

End-to-end "add to cart" flow on the storefront (product detail → Add to Cart → cart total updates ₱9,650 → ₱19,300):

[cchoice_storefront_add_to_cart.mp4](https://cursor.com/agents/bc-c790f18e-b2cc-4a36-9e7a-2592d0d5072c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcchoice_storefront_add_to_cart.mp4)

[GMA 55 product detail page](https://cursor.com/agents/bc-c790f18e-b2cc-4a36-9e7a-2592d0d5072c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcchoice_product_detail.webp)
[Cart page showing added product](https://cursor.com/agents/bc-c790f18e-b2cc-4a36-9e7a-2592d0d5072c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcchoice_cart.webp)

Testing:
- `go build -tags="fts5 staticfs" -o ./tmp/web .` — builds web binary
- `mage build` — full build with `imageprocessing`
- `go test -tags="fts5 staticfs" ./...` — all packages pass
- `go vet -tags="fts5 staticfs" ./...` — clean

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c790f18e-b2cc-4a36-9e7a-2592d0d5072c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c790f18e-b2cc-4a36-9e7a-2592d0d5072c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

