### PR TITLE
Maintenance: update sshdeploy.sh with dev/prod flags and password prompt

### DIFF
--- a/scripts/sshdeploy.sh
+++ b/scripts/sshdeploy.sh
@@ -2,32 +2,116 @@
 
 set -euf -o pipefail
 
+usage() {
+	cat <<'USAGE'
+Usage: SSH_ADDR=user@host ./scripts/sshdeploy.sh --dev|--prod
+
+Environment variables:
+  SSH_ADDR    Remote SSH address (required), e.g. user@example.com
+
+Flags:
+  --dev, -d   Deploy to ~/cchoice-dev (mage dev)
+  --prod, -p  Deploy to ~/cchoice (mage prod)
+USAGE
+}
+
 SSH_ADDR="${SSH_ADDR:-}"
 if [ -z "$SSH_ADDR" ]; then
-	echo "SSH_ADDR is not set."
+	echo "Error: SSH_ADDR environment variable is required." >&2
+	usage >&2
 	exit 1
 fi
 
-ssh "$SSH_ADDR" bash --login -i -s <<EOF
-	set -euf -o pipefail
+ENV=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--dev | -d)
+		ENV="dev"
+		;;
+	--prod | -p)
+		ENV="prod"
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Error: unknown argument '$1'." >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+	shift
+done
 
-	echo "Navigating to project directory..."
-	cd "cchoice"
+if [ -z "$ENV" ]; then
+	echo "Error: --dev or --prod flag is required." >&2
+	usage >&2
+	exit 1
+fi
 
-	echo "Syncing repository..."
+read -rsp "SSH password: " SSH_PASSWORD
+echo
+
+ssh_cmd() {
+	if command -v sshpass >/dev/null 2>&1; then
+		SSHPASS="$SSH_PASSWORD" sshpass -e ssh "$@"
+	else
+		echo "sshpass not found; ssh will prompt for password." >&2
+		ssh "$@"
+	fi
+}
+
+echo "Deploying $ENV to $SSH_ADDR..."
+
+ssh_cmd "$SSH_ADDR" bash --login -s "$ENV" <<'EOF'
+set -euf -o pipefail
+
+ENV="$1"
+
+if [ "$ENV" = "dev" ]; then
+	PROJECT_DIR=~/cchoice-dev
+	MAGE_TARGET="dev"
+	PROCESS_PATTERN="./tmp/cchoicedev api"
+else
+	PROJECT_DIR=~/cchoice
+	MAGE_TARGET="prod"
+	PROCESS_PATTERN="./tmp/cchoiceprod api"
+fi
+
+echo "Navigating to project directory..."
+cd "$PROJECT_DIR"
+
+echo "Syncing repository..."
+if ! git pull origin main; then
+	echo "Pull failed, stashing local changes and retrying..."
+	git stash push -u -m "deploy stash $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	git pull origin main
+fi
 
-	echo "Fetching tags..."
-	git fetch --prune --tags origin
+echo "Fetching tags..."
+git fetch --prune --tags origin
 
-	echo "Stopping existing process..."
-	pkill -f "./tmp/main api" || echo "No existing process found."
+echo "Stopping existing process..."
+if pgrep -af "$PROCESS_PATTERN" >/dev/null 2>&1; then
+	pkill -f "$PROCESS_PATTERN" || true
+	sleep 1
+else
+	echo "No existing process found."
+fi
 
-	echo "Building..."
-	mage prod
+echo "Building..."
+BUILD_OUTPUT=$(mage "$MAGE_TARGET" 2>&1)
+echo "$BUILD_OUTPUT"
 
-	echo "Running API..."
-	./tmp/main api > out 2>&1 &
+RUN_CMD=$(echo "$BUILD_OUTPUT" | grep '^Run: ' | sed 's/^Run: //' | sed 's/ > out.*//' | sed 's/ &//' | xargs)
+if [ -z "$RUN_CMD" ]; then
+	echo "Error: could not parse run command from mage $MAGE_TARGET output." >&2
+	exit 1
+fi
 
-	echo "Done!"
+echo "Starting API with: $RUN_CMD"
+eval "$RUN_CMD > out 2>&1 &"
+
+echo "Done!"
 EOF


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `scripts/sshdeploy.sh` to match the manual remote deployment workflow.

## Changes

- **SSH_ADDR** is now a required environment variable
- Prompts for SSH password before connecting (uses `sshpass` when available, otherwise falls back to interactive `ssh`)
- Requires `--dev` / `-d` or `--prod` / `-p` flag
  - **dev** → `~/cchoice-dev`, runs `mage dev`, kills `./tmp/cchoicedev api`
  - **prod** → `~/cchoice`, runs `mage prod`, kills `./tmp/cchoiceprod api`
- On `git pull` failure, stashes local changes and retries
- Finds and kills the existing API process via `pgrep`/`pkill`
- Parses and runs the command printed by `mage dev` / `mage prod`

## Usage

```bash
SSH_ADDR=user@host ./scripts/sshdeploy.sh --dev
SSH_ADDR=user@host ./scripts/sshdeploy.sh --prod
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a7da90c-34f3-4c3d-81ed-b57f7a4c4462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a7da90c-34f3-4c3d-81ed-b57f7a4c4462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

