### PR TITLE
Feature: Improve product page SEO for search engine indexing

### DIFF
--- a/cmd/web/components/common/common.templ
+++ b/cmd/web/components/common/common.templ
@@ -5,6 +5,7 @@ import "cchoice/internal/constants"
 import "cchoice/internal/conf"
 import "cchoice/internal/utils"
 import "cchoice/cmd/web/components/svg"
+import "cchoice/cmd/web/models"
 
 const DISCOUNT_RIBBON = true
 
@@ -33,13 +34,14 @@ templ HR() {
 }
 
 templ HeadMeta() {
+	@HeadMetaBase()
+	@HeadSEO(models.DefaultSiteSEO())
+}
+
+templ HeadMetaBase() {
 	<base href="/"/>
-	<link rel="canonical" href="https://primary.shop/"/>
 	<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
-	<meta name="description" content="Your Partner in Progress"/>
 	<meta name="google" content="nositelinkssearchbox"/>
-	<meta name="robots" content="noarchive, noimageindex"/>
-	<meta name="keywords" content="primary, c-choice, construction, power tools"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 	<!--<link rel="dns-prefetch" href="https://images1.primary.com"/>-->
 	<link rel="preload" href={ constants.PathSVGLogoWithCompleteText } as="image" type="image/svg+xml"/>
@@ -58,19 +60,6 @@ templ HeadMeta() {
 		TODO: (Brandon) - preload product images here
 		<link rel="preload" href={ utils.URL("/static/images/product_images/bosch/") } as="image" type="image/png"/>
 	-->
-	<meta property="og:title" content="C-Choice Construction Supplies"/>
-	<meta
-		property="og:description"
-		content="Your Partner in Progress"
-	/>
-	<meta property="og:type" content="website"/>
-	<!--<meta property="og:url" content="https://www.primary.com/"/>-->
-	<meta property="og:image" content="https://imagedelivery.net/YnES7emCTPeSEVA2N0dB_g/favicons-192x192/public"/>
-	<meta
-		property="og:image:secure_url"
-		content={ utils.URL("/static/images/favicons/192x192.png") }
-	/>
-	<meta name="twitter:card" content="summary"/>
 	<meta charset="UTF-8"/>
 	@onceHeadLinks.Once() {
 		<link rel="icon" type="image/x-icon" sizes={ constants.DefaultThumbnailSize } href={ utils.URL("/static/images/favicons/favicon.ico") }/>
@@ -109,6 +98,32 @@ templ HeadMeta() {
 				});
 			})();
 		</script>
+	}
+}
+
+templ HeadSEO(seo models.SiteSEO) {
+	<link rel="canonical" href={ seo.CanonicalURL }/>
+	<meta name="description" content={ seo.Description }/>
+	<meta name="robots" content={ seo.Robots }/>
+	if seo.Keywords != "" {
+		<meta name="keywords" content={ seo.Keywords }/>
+	}
+	<meta property="og:title" content={ seo.OGTitle }/>
+	<meta property="og:description" content={ seo.OGDescription }/>
+	<meta property="og:type" content={ seo.OGType }/>
+	if seo.OGURL != "" {
+		<meta property="og:url" content={ seo.OGURL }/>
+	}
+	<meta property="og:image" content={ seo.OGImage }/>
+	<meta
+		property="og:image:secure_url"
+		content={ seo.OGImage }
+	/>
+	<meta name="twitter:card" content={ seo.TwitterCard }/>
+	<meta name="twitter:title" content={ seo.OGTitle }/>
+	<meta name="twitter:description" content={ seo.OGDescription }/>
+	if seo.OGImage != "" {
+		<meta name="twitter:image" content={ seo.OGImage }/>
 	}
 }
 

--- a/cmd/web/components/common/common_templ.go
+++ b/cmd/web/components/common/common_templ.go
@@ -13,6 +13,7 @@ import "cchoice/internal/constants"
 import "cchoice/internal/conf"
 import "cchoice/internal/utils"
 import "cchoice/cmd/web/components/svg"
+import "cchoice/cmd/web/models"
 
 const DISCOUNT_RIBBON = true
 
@@ -57,7 +58,7 @@ func TabTitle(page string) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("[DEV] %s | C-Choice Construction Supply", page))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 25, Col: 71}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 26, Col: 71}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -75,7 +76,7 @@ func TabTitle(page string) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%s | C-Choice Construction Supply", page))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 27, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 28, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -140,16 +141,49 @@ func HeadMeta() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<base href=\"/\"><link rel=\"canonical\" href=\"https://primary.shop/\"><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"><meta name=\"description\" content=\"Your Partner in Progress\"><meta name=\"google\" content=\"nositelinkssearchbox\"><meta name=\"robots\" content=\"noarchive, noimageindex\"><meta name=\"keywords\" content=\"primary, c-choice, construction, power tools\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><!--<link rel=\"dns-prefetch\" href=\"https://images1.primary.com\"/>--><link rel=\"preload\" href=\"")
+		templ_7745c5c3_Err = HeadMetaBase().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var6 templ.SafeURL
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathSVGLogoWithCompleteText)
+		templ_7745c5c3_Err = HeadSEO(models.DefaultSiteSEO()).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 45, Col: 65}
+			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		return nil
+	})
+}
+
+func HeadMetaBase() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<base href=\"/\"><meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"><meta name=\"google\" content=\"nositelinkssearchbox\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><!--<link rel=\"dns-prefetch\" href=\"https://images1.primary.com\"/>--><link rel=\"preload\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 templ.SafeURL
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathSVGLogoWithCompleteText)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 47, Col: 65}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -157,12 +191,12 @@ func HeadMeta() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var7 templ.SafeURL
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathEmptyImageCDN)
+		var templ_7745c5c3_Var8 templ.SafeURL
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathEmptyImageCDN)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 48, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 50, Col: 36}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -170,29 +204,16 @@ func HeadMeta() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 templ.SafeURL
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathStoreImageCDN)
+		var templ_7745c5c3_Var9 templ.SafeURL
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(constants.PathStoreImageCDN)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 54, Col: 36}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" as=\"image\"><!--\n\t\tTODO: (Brandon) - preload product images here\n\t\t<link rel=\"preload\" href={ utils.URL(\"/static/images/product_images/bosch/\") } as=\"image\" type=\"image/png\"/>\n\t--><meta property=\"og:title\" content=\"C-Choice Construction Supplies\"><meta property=\"og:description\" content=\"Your Partner in Progress\"><meta property=\"og:type\" content=\"website\"><!--<meta property=\"og:url\" content=\"https://www.primary.com/\"/>--><meta property=\"og:image\" content=\"https://imagedelivery.net/YnES7emCTPeSEVA2N0dB_g/favicons-192x192/public\"><meta property=\"og:image:secure_url\" content=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/static/images/favicons/192x192.png"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 71, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 56, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"><meta name=\"twitter:card\" content=\"summary\"><meta charset=\"UTF-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" as=\"image\"><!--\n\t\tTODO: (Brandon) - preload product images here\n\t\t<link rel=\"preload\" href={ utils.URL(\"/static/images/product_images/bosch/\") } as=\"image\" type=\"image/png\"/>\n\t--><meta charset=\"UTF-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -208,91 +229,104 @@ func HeadMeta() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<link rel=\"icon\" type=\"image/x-icon\" sizes=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<link rel=\"icon\" type=\"image/x-icon\" sizes=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(constants.DefaultThumbnailSize)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 76, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 65, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/static/images/favicons/favicon.ico"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 76, Col: 135}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 65, Col: 135}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, size := range faviconsizes {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<link rel=\"icon\" type=\"image/png\" sizes=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<link rel=\"icon\" type=\"image/png\" sizes=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(size)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 78, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 67, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 templ.SafeURL
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(fmt.Sprintf("https://imagedelivery.net/YnES7emCTPeSEVA2N0dB_g/favicons-%s/public", size))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 78, Col: 147}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 67, Col: 147}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " <link href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " <link href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var15 templ.SafeURL
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/static/css/tailwind.css"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 80, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 69, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" rel=\"stylesheet\"><script type=\"text/javascript\" src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" rel=\"stylesheet\"><script type=\"text/javascript\" src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(templ.URL(utils.URL("/static/js/htmx.min.js")))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 81, Col: 85}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 70, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"></script> <script async type=\"text/javascript\" src=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(templ.URL(utils.URL("/static/js/hyperscript.min.js")))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 71, Col: 98}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -300,29 +334,16 @@ func HeadMeta() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var17 string
-			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(templ.URL(utils.URL("/static/js/hyperscript.min.js")))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 82, Col: 98}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"></script> <script async type=\"text/javascript\" src=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(templ.URL(utils.URL("/static/js/metrics.js")))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 83, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 72, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\"></script> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"></script> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -330,7 +351,7 @@ func HeadMeta() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -338,7 +359,7 @@ func HeadMeta() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " <script>\n\t\t\t(function(){\n\t\t\t\tif (!globalThis._G) {\n\t\t\t\t\tglobalThis._G = {};\n\t\t\t\t}\n\t\t\t\tconst urlPrefix = JSON.parse(document.getElementById(\"url-prefix\").textContent);\n\t\t\t\tObject.defineProperty(globalThis._G, \"URL_PREFIX\", {\n\t\t\t\t\tvalue: urlPrefix,\n\t\t\t\t\twritable: false,\n\t\t\t\t\tconfigurable: false\n\t\t\t\t});\n\t\t\t\tObject.defineProperty(globalThis._G, \"VERSION\", {\n\t\t\t\t\tvalue: async function() {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tconst resp = await fetch(urlPrefix + \"/version\", { cache: \"no-store\" });\n\t\t\t\t\t\t\tif (!resp.ok) { return \"\"; }\n\t\t\t\t\t\t\treturn await resp.text();\n\t\t\t\t\t\t} catch (_) {\n\t\t\t\t\t\t\treturn \"\";\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\twritable: false,\n\t\t\t\t\tconfigurable: false\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " <script>\n\t\t\t(function(){\n\t\t\t\tif (!globalThis._G) {\n\t\t\t\t\tglobalThis._G = {};\n\t\t\t\t}\n\t\t\t\tconst urlPrefix = JSON.parse(document.getElementById(\"url-prefix\").textContent);\n\t\t\t\tObject.defineProperty(globalThis._G, \"URL_PREFIX\", {\n\t\t\t\t\tvalue: urlPrefix,\n\t\t\t\t\twritable: false,\n\t\t\t\t\tconfigurable: false\n\t\t\t\t});\n\t\t\t\tObject.defineProperty(globalThis._G, \"VERSION\", {\n\t\t\t\t\tvalue: async function() {\n\t\t\t\t\t\ttry {\n\t\t\t\t\t\t\tconst resp = await fetch(urlPrefix + \"/version\", { cache: \"no-store\" });\n\t\t\t\t\t\t\tif (!resp.ok) { return \"\"; }\n\t\t\t\t\t\t\treturn await resp.text();\n\t\t\t\t\t\t} catch (_) {\n\t\t\t\t\t\t\treturn \"\";\n\t\t\t\t\t\t}\n\t\t\t\t\t},\n\t\t\t\t\twritable: false,\n\t\t\t\t\tconfigurable: false\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -347,6 +368,243 @@ func HeadMeta() templ.Component {
 		templ_7745c5c3_Err = onceHeadLinks.Once().Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func HeadSEO(seo models.SiteSEO) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<link rel=\"canonical\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var20 templ.SafeURL
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinURLErrs(seo.CanonicalURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 105, Col: 46}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"><meta name=\"description\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(seo.Description)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 106, Col: 51}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><meta name=\"robots\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(seo.Robots)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 107, Col: 41}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if seo.Keywords != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<meta name=\"keywords\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var23 string
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(seo.Keywords)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 109, Col: 46}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<meta property=\"og:title\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGTitle)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 111, Col: 48}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"><meta property=\"og:description\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var25 string
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGDescription)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 112, Col: 60}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\"><meta property=\"og:type\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var26 string
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGType)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 113, Col: 46}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if seo.OGURL != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<meta property=\"og:url\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGURL)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 115, Col: 45}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<meta property=\"og:image\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGImage)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 117, Col: 48}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\"><meta property=\"og:image:secure_url\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var29 string
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGImage)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 120, Col: 23}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"><meta name=\"twitter:card\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(seo.TwitterCard)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 122, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"><meta name=\"twitter:title\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGTitle)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 123, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\"><meta name=\"twitter:description\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGDescription)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 124, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if seo.OGImage != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<meta name=\"twitter:image\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(seo.OGImage)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 126, Col: 50}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})
@@ -372,51 +630,51 @@ func IconActionButton(
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
+		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var34 == nil {
+			templ_7745c5c3_Var34 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"my-2 flex flex-col place-center\"><button aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div class=\"my-2 flex flex-col place-center\"><button aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		var templ_7745c5c3_Var35 string
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 122, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 137, Col: 21}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" title=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(label)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 123, Col: 16}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" class=\"relative inline-block group py-2 stroke-primary rounded-full cursor-pointer hover:bg-primary-dark text-nowrap items-center flex flex-col text-xs text-primary hover:text-white\" _=\"")
+		var templ_7745c5c3_Var36 string
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 138, Col: 16}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("on click go to url '" + utils.URL(href) + "'")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 131, Col: 53}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\" class=\"relative inline-block group py-2 stroke-primary rounded-full cursor-pointer hover:bg-primary-dark text-nowrap items-center flex flex-col text-xs text-primary hover:text-white\" _=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\">")
+		var templ_7745c5c3_Var37 string
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs("on click go to url '" + utils.URL(href) + "'")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 146, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -426,7 +684,7 @@ func IconActionButton(
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<!-- <span class=\"hidden md:block\">{ label }</span> --><!-- <span>{ label }</span> --></button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<!-- <span class=\"hidden md:block\">{ label }</span> --><!-- <span>{ label }</span> --></button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -454,25 +712,25 @@ func IconAction(
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var23 == nil {
-			templ_7745c5c3_Var23 = templ.NopComponent
+		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var38 == nil {
+			templ_7745c5c3_Var38 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"my-2 flex flex-col place-center relative inline-block group py-2 stroke-primary rounded-full w-16 cursor-pointer hover:bg-primary-dark text-nowrap items-center flex flex-col text-xs text-primary hover:text-white\" _=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"my-2 flex flex-col place-center relative inline-block group py-2 stroke-primary rounded-full w-16 cursor-pointer hover:bg-primary-dark text-nowrap items-center flex flex-col text-xs text-primary hover:text-white\" _=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var24 string
-		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs("on click go to url '" + utils.URL(href) + "'")
+		var templ_7745c5c3_Var39 string
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs("on click go to url '" + utils.URL(href) + "'")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 156, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 171, Col: 52}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -482,7 +740,7 @@ func IconAction(
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -506,25 +764,25 @@ func ContinueShopping() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var40 == nil {
+			templ_7745c5c3_Var40 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var26 templ.SafeURL
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(utils.URL("/")))
+		var templ_7745c5c3_Var41 templ.SafeURL
+		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(utils.URL("/")))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 166, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 181, Col: 38}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"flex justify-center items-center relative inline-block px-6 py-3 bg-primary font-medium rounded-lg text-white cursor-pointer transition-colors rounded-full hover:bg-surface\" title=\"Continue shopping\" alt=\"Continue shopping button\">Continue Shopping</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" class=\"flex justify-center items-center relative inline-block px-6 py-3 bg-primary font-medium rounded-lg text-white cursor-pointer transition-colors rounded-full hover:bg-surface\" title=\"Continue shopping\" alt=\"Continue shopping button\">Continue Shopping</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -548,25 +806,25 @@ func GMapsLink(url string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var27 == nil {
-			templ_7745c5c3_Var27 = templ.NopComponent
+		templ_7745c5c3_Var42 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var42 == nil {
+			templ_7745c5c3_Var42 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var28 templ.SafeURL
-		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinURLErrs(url)
+		var templ_7745c5c3_Var43 templ.SafeURL
+		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinURLErrs(url)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 181, Col: 12}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 196, Col: 12}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open in Google Maps\" title=\"Open in Google Maps\" class=\"inline-flex items-center gap-2 p-2 rounded-md text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50 transition\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"w-6 h-6\"><path d=\"M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5z\"></path></svg> <span class=\"text-sm font-medium\">Google Maps</span></a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open in Google Maps\" title=\"Open in Google Maps\" class=\"inline-flex items-center gap-2 p-2 rounded-md text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50 transition\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"w-6 h-6\"><path d=\"M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5A2.5 2.5 0 1 1 12 6a2.5 2.5 0 0 1 0 5.5z\"></path></svg> <span class=\"text-sm font-medium\">Google Maps</span></a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -590,25 +848,25 @@ func WazeLink(url string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var29 == nil {
-			templ_7745c5c3_Var29 = templ.NopComponent
+		templ_7745c5c3_Var44 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var44 == nil {
+			templ_7745c5c3_Var44 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var30 templ.SafeURL
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(url)
+		var templ_7745c5c3_Var45 templ.SafeURL
+		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinURLErrs(url)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 208, Col: 12}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 223, Col: 12}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open in Waze\" title=\"Open in Waze\" class=\"inline-flex items-center gap-2 p-2 rounded-md text-sky-600 hover:text-sky-700 hover:bg-sky-50 transition\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"w-6 h-6\"><path d=\"M12 2C6.48 2 2 6.03 2 11c0 3.04 1.74 5.73 4.4 7.4L6 22l4.07-2.03c.63.1 1.27.15 1.93.15 5.52 0 10-4.03 10-9s-4.48-9-10-9zm-3 9a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm6 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\"></path></svg> <span class=\"text-sm font-medium\">Waze</span></a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Open in Waze\" title=\"Open in Waze\" class=\"inline-flex items-center gap-2 p-2 rounded-md text-sky-600 hover:text-sky-700 hover:bg-sky-50 transition\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"w-6 h-6\"><path d=\"M12 2C6.48 2 2 6.03 2 11c0 3.04 1.74 5.73 4.4 7.4L6 22l4.07-2.03c.63.1 1.27.15 1.93.15 5.52 0 10-4.03 10-9s-4.48-9-10-9zm-3 9a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm6 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z\"></path></svg> <span class=\"text-sm font-medium\">Waze</span></a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -632,26 +890,26 @@ func DiscountRibbon(percentage string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var31 == nil {
-			templ_7745c5c3_Var31 = templ.NopComponent
+		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var46 == nil {
+			templ_7745c5c3_Var46 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if DISCOUNT_RIBBON && percentage != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div class=\"absolute w-full bottom-0 mb-1 bg-white/50 text-primary text-sm font-bold tracking-wide text-center\">-")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<div class=\"absolute w-full bottom-0 mb-1 bg-white/50 text-primary text-sm font-bold tracking-wide text-center\">-")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(percentage)
+			var templ_7745c5c3_Var47 string
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(percentage)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 243, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 258, Col: 16}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -679,25 +937,25 @@ func AddToCart() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var33 == nil {
-			templ_7745c5c3_Var33 = templ.NopComponent
+		templ_7745c5c3_Var48 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var48 == nil {
+			templ_7745c5c3_Var48 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<button id=\"btn-add-to-cart\" class=\"flex justify-center items-center relative inline-block w-12 h-12 bg-primary font-medium rounded-lg text-sm p-1 cursor-pointer m-2 transition-colors group rounded-full hover:bg-surface\" title=\"add to cart\" alt=\"add to cart button\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<button id=\"btn-add-to-cart\" class=\"flex justify-center items-center relative inline-block w-12 h-12 bg-primary font-medium rounded-lg text-sm p-1 cursor-pointer m-2 transition-colors group rounded-full hover:bg-surface\" title=\"add to cart\" alt=\"add to cart button\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines"))
+		var templ_7745c5c3_Var49 string
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 260, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 275, Col: 37}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" hx-include=\"#selected-product-id\" hx-swap=\"none\" _=\"\n\t\t\ton click\n\t\t\t\tasync call metrics_event('add_to_cart', #selected-product-id.value)\n\t\t\t\tlog 'Added to cart: ' + #selected-product-id.value\n\t\t\t\thalt\n\t\t\tend\n\t\t\ton htmx:afterRequest\n\t\t\t\ttrigger get on #cart-count-desktop\n\t\t\t\ttrigger get on #cart-count-mobile\n\t\t\t\tif #cart-icon-desktop\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-desktop\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-desktop\n\t\t\t\tend\n\t\t\t\tif #cart-icon-mobile\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-mobile\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-mobile\n\t\t\t\tend\n\t\t\tend\n\t\t\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" hx-include=\"#selected-product-id\" hx-swap=\"none\" _=\"\n\t\t\ton click\n\t\t\t\tasync call metrics_event('add_to_cart', #selected-product-id.value)\n\t\t\t\tlog 'Added to cart: ' + #selected-product-id.value\n\t\t\t\thalt\n\t\t\tend\n\t\t\ton htmx:afterRequest\n\t\t\t\ttrigger get on #cart-count-desktop\n\t\t\t\ttrigger get on #cart-count-mobile\n\t\t\t\tif #cart-icon-desktop\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-desktop\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-desktop\n\t\t\t\tend\n\t\t\t\tif #cart-icon-mobile\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-mobile\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-mobile\n\t\t\t\tend\n\t\t\tend\n\t\t\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -705,7 +963,7 @@ func AddToCart() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 shadow\">+1</span></button> <input type=\"hidden\" id=\"selected-product-id\" name=\"product_id\" value=\"\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<span class=\"absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 shadow\">+1</span></button> <input type=\"hidden\" id=\"selected-product-id\" name=\"product_id\" value=\"\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -729,13 +987,13 @@ func DevRibbon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var35 == nil {
-			templ_7745c5c3_Var35 = templ.NopComponent
+		templ_7745c5c3_Var50 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var50 == nil {
+			templ_7745c5c3_Var50 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if !conf.Conf().IsProd() {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div class=\"fixed top-0 right-0 w-24 h-24 -mr-12 -mt-12 bg-red-600/80 rotate-45 flex items-center justify-center z-999 shadow-lg\"><span class=\"text-white font-bold text-sm tracking-wider mt-16\">DEV</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<div class=\"fixed top-0 right-0 w-24 h-24 -mr-12 -mt-12 bg-red-600/80 rotate-45 flex items-center justify-center z-999 shadow-lg\"><span class=\"text-white font-bold text-sm tracking-wider mt-16\">DEV</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -760,25 +1018,25 @@ func BackToShopLink() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var36 == nil {
-			templ_7745c5c3_Var36 = templ.NopComponent
+		templ_7745c5c3_Var51 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var51 == nil {
+			templ_7745c5c3_Var51 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var37 templ.SafeURL
-		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/"))
+		var templ_7745c5c3_Var52 templ.SafeURL
+		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 320, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 335, Col: 23}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\" class=\"inline-flex items-center gap-1 text-sm text-primary hover:text-primary-dark mb-4\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M10 19l-7-7m0 0l7-7m-7 7h18\"></path></svg> Back to Shop</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" class=\"inline-flex items-center gap-1 text-sm text-primary hover:text-primary-dark mb-4\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M10 19l-7-7m0 0l7-7m-7 7h18\"></path></svg> Back to Shop</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -802,25 +1060,25 @@ func ReleaseNotesLink() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var38 == nil {
-			templ_7745c5c3_Var38 = templ.NopComponent
+		templ_7745c5c3_Var53 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var53 == nil {
+			templ_7745c5c3_Var53 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var39 templ.SafeURL
-		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/changelogs"))
+		var templ_7745c5c3_Var54 templ.SafeURL
+		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/changelogs"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 332, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 347, Col: 33}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" class=\"inline-flex items-center gap-1 text-sm text-primary hover:text-primary-dark mb-4\">Release Notes <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M14 5l7 7m0 0l-7 7m7-7H3\"></path></svg></a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\" class=\"inline-flex items-center gap-1 text-sm text-primary hover:text-primary-dark mb-4\">Release Notes <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M14 5l7 7m0 0l-7 7m7-7H3\"></path></svg></a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -844,25 +1102,25 @@ func AddToCartPromoProduct() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var40 == nil {
-			templ_7745c5c3_Var40 = templ.NopComponent
+		templ_7745c5c3_Var55 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var55 == nil {
+			templ_7745c5c3_Var55 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<button id=\"btn-add-to-cart\" class=\"flex justify-center items-center relative inline-block w-12 h-12 bg-primary font-medium rounded-lg text-sm p-1 cursor-pointer m-2 transition-colors group rounded-full hover:bg-surface\" title=\"add to cart\" alt=\"add to cart button\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<button id=\"btn-add-to-cart\" class=\"flex justify-center items-center relative inline-block w-12 h-12 bg-primary font-medium rounded-lg text-sm p-1 cursor-pointer m-2 transition-colors group rounded-full hover:bg-surface\" title=\"add to cart\" alt=\"add to cart button\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var41 string
-		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines"))
+		var templ_7745c5c3_Var56 string
+		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 352, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `common/common.templ`, Line: 367, Col: 37}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" hx-include=\"#promo-product-id\" hx-swap=\"none\" _=\"\n\t\t\ton click\n\t\t\t\tasync call metrics_event('add_to_cart', #promo-product-id.value)\n\t\t\t\tlog 'Added to cart: ' + #promo-product-id.value\n\t\t\t\thalt\n\t\t\tend\n\t\t\ton htmx:afterRequest\n\t\t\t\ttrigger get on #cart-count-desktop\n\t\t\t\ttrigger get on #cart-count-mobile\n\t\t\t\tif #cart-icon-desktop\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-desktop\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-desktop\n\t\t\t\tend\n\t\t\t\tif #cart-icon-mobile\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-mobile\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-mobile\n\t\t\t\tend\n\t\t\tend\n\t\t\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\" hx-include=\"#promo-product-id\" hx-swap=\"none\" _=\"\n\t\t\ton click\n\t\t\t\tasync call metrics_event('add_to_cart', #promo-product-id.value)\n\t\t\t\tlog 'Added to cart: ' + #promo-product-id.value\n\t\t\t\thalt\n\t\t\tend\n\t\t\ton htmx:afterRequest\n\t\t\t\ttrigger get on #cart-count-desktop\n\t\t\t\ttrigger get on #cart-count-mobile\n\t\t\t\tif #cart-icon-desktop\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-desktop\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-desktop\n\t\t\t\tend\n\t\t\t\tif #cart-icon-mobile\n\t\t\t\t\tadd .cart-icon-animate to #cart-icon-mobile\n\t\t\t\t\twait 400ms\n\t\t\t\t\tremove .cart-icon-animate from #cart-icon-mobile\n\t\t\t\tend\n\t\t\tend\n\t\t\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -870,7 +1128,7 @@ func AddToCartPromoProduct() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<span class=\"absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 shadow\">+1</span></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<span class=\"absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full px-1.5 shadow\">+1</span></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/cmd/web/components/product/common.templ
+++ b/cmd/web/components/product/common.templ
@@ -2,7 +2,31 @@ package product
 
 import "cchoice/cmd/web/models"
 
-templ Meta(meta models.ProductsMeta) {
+templ ProductSEO(meta models.ProductsMeta) {
 	<title>{ meta.Title }</title>
+	<link rel="canonical" href={ meta.CanonicalURL }/>
 	<meta name="description" content={ meta.Content }/>
+	<meta name="robots" content={ meta.Robots }/>
+	if meta.Keywords != "" {
+		<meta name="keywords" content={ meta.Keywords }/>
+	}
+	<meta property="og:title" content={ meta.Title }/>
+	<meta property="og:description" content={ meta.Content }/>
+	<meta property="og:type" content={ meta.OGType }/>
+	<meta property="og:url" content={ meta.CanonicalURL }/>
+	if meta.OGImage != "" {
+		<meta property="og:image" content={ meta.OGImage }/>
+		<meta property="og:image:secure_url" content={ meta.OGImage }/>
+	}
+	<meta name="twitter:card" content={ meta.TwitterCard }/>
+	<meta name="twitter:title" content={ meta.Title }/>
+	<meta name="twitter:description" content={ meta.Content }/>
+	if meta.OGImage != "" {
+		<meta name="twitter:image" content={ meta.OGImage }/>
+	}
+	if meta.StructuredData != "" {
+		<script type="application/ld+json">
+			{ meta.StructuredData }
+		</script>
+	}
 }

--- a/cmd/web/components/product/common_templ.go
+++ b/cmd/web/components/product/common_templ.go
@@ -10,7 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import "cchoice/cmd/web/models"
 
-func Meta(meta models.ProductsMeta) templ.Component {
+func ProductSEO(meta models.ProductsMeta) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -44,22 +44,223 @@ func Meta(meta models.ProductsMeta) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><meta name=\"description\" content=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><link rel=\"canonical\" href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Content)
+		var templ_7745c5c3_Var3 templ.SafeURL
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(meta.CanonicalURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 7, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 7, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"><meta name=\"description\" content=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Content)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 8, Col: 48}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"><meta name=\"robots\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Robots)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 9, Col: 42}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if meta.Keywords != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<meta name=\"keywords\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Keywords)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 11, Col: 47}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<meta property=\"og:title\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 13, Col: 47}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"><meta property=\"og:description\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Content)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 14, Col: 55}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"><meta property=\"og:type\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(meta.OGType)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 15, Col: 47}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"><meta property=\"og:url\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(meta.CanonicalURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 16, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if meta.OGImage != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<meta property=\"og:image\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(meta.OGImage)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 18, Col: 50}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><meta property=\"og:image:secure_url\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(meta.OGImage)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 19, Col: 61}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<meta name=\"twitter:card\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(meta.TwitterCard)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 21, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"><meta name=\"twitter:title\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 22, Col: 48}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><meta name=\"twitter:description\" content=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(meta.Content)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 23, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if meta.OGImage != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<meta name=\"twitter:image\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(meta.OGImage)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/common.templ`, Line: 25, Col: 51}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if meta.StructuredData != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<script type=\"application/ld+json\">\n\t\t\t{ meta.StructuredData }\n\t\t</script>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})

--- a/cmd/web/components/product/page.templ
+++ b/cmd/web/components/product/page.templ
@@ -11,9 +11,8 @@ templ ProductPage(data models.ProductPageData) {
 	<!DOCTYPE html>
 	<html lang="en" class="overflow-x-hidden">
 		<head>
-			@common.HeadMeta()
-			<!-- @common.TabTitle(data.Name + " | CChoice") -->
-			@Meta(data.Meta)
+			@common.HeadMetaBase()
+			@ProductSEO(data.Meta)
 		</head>
 		<body class="min-h-screen flex flex-col bg-white">
 			@common.DevRibbon()

--- a/cmd/web/components/product/page_templ.go
+++ b/cmd/web/components/product/page_templ.go
@@ -40,19 +40,15 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = common.HeadMeta().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = common.HeadMetaBase().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<!-- @common.TabTitle(data.Name + \" | CChoice\") -->")
+		templ_7745c5c3_Err = ProductSEO(data.Meta).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Meta(data.Meta).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</head><body class=\"min-h-screen flex flex-col bg-white\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</head><body class=\"min-h-screen flex flex-col bg-white\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -72,7 +68,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<main class=\"flex-1 w-full max-w-8xl mx-auto px-4 py-8 mb-24 lg:mb-12\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<main class=\"flex-1 w-full max-w-8xl mx-auto px-4 py-8 mb-24 lg:mb-12\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -80,7 +76,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"grid grid-cols-1 lg:grid-cols-2 gap-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"grid grid-cols-1 lg:grid-cols-2 gap-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -88,7 +84,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"flex flex-col gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"flex flex-col gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -108,20 +104,20 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"flex flex-col gap-1 text-sm text-gray-600 mt-4\"><h4 class=\"text-md font-bold\">Product Description:</h4><p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"flex flex-col gap-1 text-sm text-gray-600 mt-4\"><h4 class=\"text-md font-bold\">Product Description:</h4><p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(data.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/page.templ`, Line: 34, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/page.templ`, Line: 33, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</p></div><div class=\"mt-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</p></div><div class=\"mt-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -129,7 +125,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -137,7 +133,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</main>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</main>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -145,7 +141,7 @@ func ProductPage(data models.ProductPageData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/cmd/web/components/product/related.templ
+++ b/cmd/web/components/product/related.templ
@@ -10,7 +10,7 @@ templ RelatedProducts(products []models.RelatedProduct) {
 			<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
 				for _, p := range products {
 					<a
-						href={ utils.URL("/product/" + p.ProductID) }
+						href={ utils.URL("/product/" + p.Slug) }
 						class="flex flex-col gap-2 p-3 border rounded-lg hover:shadow-lg transition-shadow"
 					>
 						<div class="aspect-square bg-gray-100 rounded-lg overflow-hidden">

--- a/cmd/web/components/product/related_templ.go
+++ b/cmd/web/components/product/related_templ.go
@@ -43,9 +43,9 @@ func RelatedProducts(products []models.RelatedProduct) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var2 templ.SafeURL
-				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/product/" + p.ProductID))
+				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/product/" + p.Slug))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/related.templ`, Line: 13, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `product/related.templ`, Line: 13, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 				if templ_7745c5c3_Err != nil {

--- a/cmd/web/models/homepage.go
+++ b/cmd/web/models/homepage.go
@@ -62,6 +62,7 @@ type ProductSpec struct {
 
 type ProductPageData struct {
 	Meta                       ProductsMeta
+	Slug                       string
 	ProductID                  string
 	Serial                     string
 	Name                       string
@@ -90,6 +91,7 @@ type ProductPageData struct {
 
 type RelatedProduct struct {
 	ProductID          string
+	Slug               string
 	Name               string
 	Serial             string
 	BrandName          string

--- a/cmd/web/models/meta.go
+++ b/cmd/web/models/meta.go
@@ -1,6 +1,48 @@
 package models
 
+import "cchoice/internal/utils"
+
 type ProductsMeta struct {
-	Title   string
-	Content string
+	Title           string
+	Content         string
+	CanonicalURL    string
+	OGImage         string
+	OGType          string
+	Robots          string
+	Keywords        string
+	StructuredData  string
+	PriceAmount     string
+	PriceCurrency   string
+	TwitterCard     string
+}
+
+type SiteSEO struct {
+	Title          string
+	Description    string
+	CanonicalURL   string
+	Robots         string
+	Keywords       string
+	OGTitle        string
+	OGDescription  string
+	OGType         string
+	OGURL          string
+	OGImage        string
+	TwitterCard    string
+}
+
+func DefaultSiteSEO() SiteSEO {
+	canonical := utils.SiteURL("/")
+	return SiteSEO{
+		Title:         "C-Choice Construction Supply",
+		Description:   "Your Partner in Progress. Quality construction tools and materials from trusted brands in the Philippines.",
+		CanonicalURL:  canonical,
+		Robots:        "index, follow",
+		Keywords:      "c-choice, construction, power tools, philippines",
+		OGTitle:       "C-Choice Construction Supplies",
+		OGDescription: "Your Partner in Progress",
+		OGType:        "website",
+		OGURL:         canonical,
+		OGImage:       "https://imagedelivery.net/YnES7emCTPeSEVA2N0dB_g/favicons-192x192/public",
+		TwitterCard:   "summary",
+	}
 }

--- a/cmd/web/static/robots.txt
+++ b/cmd/web/static/robots.txt
@@ -9,8 +9,14 @@ Disallow: /metrics/event
 # Internal configuration
 Disallow: /settings/
 
+# Admin and customer areas
+Disallow: /admin/
+Disallow: /customer/
+Disallow: /auth/
+
 # Non-crawlable actions
 Disallow: /search
+Disallow: /carts/
 
 # Prevent query param explosion
 Disallow: /*?*
@@ -19,9 +25,9 @@ Disallow: /*?*
 Allow: /products/image
 Allow: /brands/logo
 Allow: /assets/image
+Allow: /product/
 
-# Optional (add when ready)
-# Sitemap: https://cchoice.shop/sitemap.xml
+# __SITEMAP__
 
 User-agent: Googlebot
 Disallow:

--- a/internal/database/queries/product.sql.go
+++ b/internal/database/queries/product.sql.go
@@ -691,6 +691,7 @@ func (q *Queries) GetProductIDBySerial(ctx context.Context, serial string) (int6
 const getProductPage = `-- name: GetProductPage :one
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.serial,
 	tbl_products.name,
 	tbl_products.description,
@@ -707,6 +708,7 @@ SELECT
 	tbl_brand_images.s3_url AS brand_thumbnail_url,
 	COALESCE(pc.category, '') AS product_category,
 	COALESCE(pc.subcategory, '') AS product_subcategory,
+	pc.id AS category_id,
 	COALESCE(tbl_product_images.path, '') AS image_path,
 	COALESCE(tbl_product_images.thumbnail, '') AS thumbnail_path,
 	COALESCE(tbl_product_images.cdn_url, '') AS cdn_url,
@@ -763,6 +765,7 @@ LIMIT 1
 
 type GetProductPageRow struct {
 	ID                          int64
+	Slug                        sql.NullString
 	Serial                      string
 	Name                        string
 	Description                 sql.NullString
@@ -779,6 +782,7 @@ type GetProductPageRow struct {
 	BrandThumbnailUrl           sql.NullString
 	ProductCategory             string
 	ProductSubcategory          string
+	CategoryID                  sql.NullInt64
 	ImagePath                   string
 	ThumbnailPath               string
 	CdnUrl                      string
@@ -804,6 +808,7 @@ func (q *Queries) GetProductPage(ctx context.Context, slug sql.NullString) (GetP
 	var i GetProductPageRow
 	err := row.Scan(
 		&i.ID,
+		&i.Slug,
 		&i.Serial,
 		&i.Name,
 		&i.Description,
@@ -820,6 +825,7 @@ func (q *Queries) GetProductPage(ctx context.Context, slug sql.NullString) (GetP
 		&i.BrandThumbnailUrl,
 		&i.ProductCategory,
 		&i.ProductSubcategory,
+		&i.CategoryID,
 		&i.ImagePath,
 		&i.ThumbnailPath,
 		&i.CdnUrl,
@@ -1427,6 +1433,7 @@ func (q *Queries) GetRandomProductOnSale(ctx context.Context) (GetRandomProductO
 const getRelatedProductsByCategory = `-- name: GetRelatedProductsByCategory :many
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.name,
 	tbl_products.serial,
 	tbl_products.unit_price_with_vat,
@@ -1469,6 +1476,7 @@ type GetRelatedProductsByCategoryParams struct {
 
 type GetRelatedProductsByCategoryRow struct {
 	ID                       int64
+	Slug                     sql.NullString
 	Name                     string
 	Serial                   string
 	UnitPriceWithVat         int64
@@ -1493,6 +1501,7 @@ func (q *Queries) GetRelatedProductsByCategory(ctx context.Context, arg GetRelat
 		var i GetRelatedProductsByCategoryRow
 		if err := rows.Scan(
 			&i.ID,
+			&i.Slug,
 			&i.Name,
 			&i.Serial,
 			&i.UnitPriceWithVat,
@@ -1505,6 +1514,45 @@ func (q *Queries) GetRelatedProductsByCategory(ctx context.Context, arg GetRelat
 			&i.SalePriceWithVat,
 			&i.SalePriceWithVatCurrency,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listActiveProductSlugs = `-- name: ListActiveProductSlugs :many
+SELECT
+	slug,
+	updated_at
+FROM tbl_products
+WHERE status = 'ACTIVE'
+	AND slug != ''
+	AND slug IS NOT NULL
+ORDER BY updated_at DESC
+`
+
+type ListActiveProductSlugsRow struct {
+	Slug      sql.NullString
+	UpdatedAt time.Time
+}
+
+func (q *Queries) ListActiveProductSlugs(ctx context.Context) ([]ListActiveProductSlugsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listActiveProductSlugs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveProductSlugsRow
+	for rows.Next() {
+		var i ListActiveProductSlugsRow
+		if err := rows.Scan(&i.Slug, &i.UpdatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/database/sql/product.sql
+++ b/internal/database/sql/product.sql
@@ -462,6 +462,7 @@ WHERE id = ?;
 -- name: GetProductPage :one
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.serial,
 	tbl_products.name,
 	tbl_products.description,
@@ -478,6 +479,7 @@ SELECT
 	tbl_brand_images.s3_url AS brand_thumbnail_url,
 	COALESCE(pc.category, '') AS product_category,
 	COALESCE(pc.subcategory, '') AS product_subcategory,
+	pc.id AS category_id,
 	COALESCE(tbl_product_images.path, '') AS image_path,
 	COALESCE(tbl_product_images.thumbnail, '') AS thumbnail_path,
 	COALESCE(tbl_product_images.cdn_url, '') AS cdn_url,
@@ -534,6 +536,7 @@ LIMIT 1;
 -- name: GetRelatedProductsByCategory :many
 SELECT
 	tbl_products.id,
+	tbl_products.slug,
 	tbl_products.name,
 	tbl_products.serial,
 	tbl_products.unit_price_with_vat,
@@ -590,3 +593,13 @@ UPDATE tbl_products SET slug = ? WHERE id = ?;
 
 -- name: GetProductSlugByID :one
 SELECT slug, status, serial FROM tbl_products WHERE id = ? LIMIT 1;
+
+-- name: ListActiveProductSlugs :many
+SELECT
+	slug,
+	updated_at
+FROM tbl_products
+WHERE status = 'ACTIVE'
+	AND slug != ''
+	AND slug IS NOT NULL
+ORDER BY updated_at DESC;

--- a/internal/seo/seo.go
+++ b/internal/seo/seo.go
@@ -1,0 +1,256 @@
+package seo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ProductRobots      = "index, follow, max-image-preview:large"
+	ProductOGType        = "product"
+	ProductTwitterCard   = "summary_large_image"
+	DefaultOGImage       = "https://imagedelivery.net/YnES7emCTPeSEVA2N0dB_g/favicons-192x192/public"
+	SitemapPlaceholder   = "# __SITEMAP__"
+)
+
+type Product struct {
+	BrandName          string
+	Name               string
+	Serial             string
+	Description        string
+	ProductCategory    string
+	ProductSubcategory string
+}
+
+type ProductMeta struct {
+	Title          string
+	Description    string
+	CanonicalURL   string
+	OGImage        string
+	OGType         string
+	Robots         string
+	Keywords       string
+	TwitterCard    string
+	PriceAmount    string
+	PriceCurrency  string
+	StructuredData string
+}
+
+type SitemapEntry struct {
+	Loc        string
+	LastMod    time.Time
+	ChangeFreq string
+	Priority   string
+}
+
+func ProductCanonicalURL(siteBaseURL, slug string) string {
+	return strings.TrimSuffix(siteBaseURL, "/") + "/product/" + slug
+}
+
+func InjectSitemapLine(content, sitemapURL string) string {
+	return strings.Replace(content, SitemapPlaceholder, "Sitemap: "+sitemapURL, 1)
+}
+
+func EscapeXML(s string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"'", "&apos;",
+		"\"", "&quot;",
+	)
+	return replacer.Replace(s)
+}
+
+func WriteSitemapURL(buf *bytes.Buffer, entry SitemapEntry) {
+	fmt.Fprintf(buf, "<url><loc>%s</loc>", EscapeXML(entry.Loc))
+	fmt.Fprintf(buf, "<lastmod>%s</lastmod>", entry.LastMod.Format("2006-01-02"))
+	fmt.Fprintf(buf, "<changefreq>%s</changefreq>", entry.ChangeFreq)
+	fmt.Fprintf(buf, "<priority>%s</priority></url>", entry.Priority)
+}
+
+func BuildSitemapXML(homeURL string, products []SitemapEntry) string {
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	buf.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+
+	WriteSitemapURL(&buf, SitemapEntry{
+		Loc:        homeURL,
+		LastMod:    time.Now().UTC(),
+		ChangeFreq: "daily",
+		Priority:   "1.0",
+	})
+
+	for _, product := range products {
+		WriteSitemapURL(&buf, product)
+	}
+
+	buf.WriteString(`</urlset>`)
+	return buf.String()
+}
+
+func GenerateProductMeta(
+	product Product,
+	canonicalURL string,
+	homeURL string,
+	imageURL string,
+	priceAmount string,
+	priceCurrency string,
+) ProductMeta {
+	title := fmt.Sprintf(
+		"%s %s (%s) - Price, Specs, Buy Online | C-Choice",
+		product.BrandName,
+		product.Name,
+		product.Serial,
+	)
+
+	description := strings.TrimSpace(product.Description)
+	if description == "" {
+		description = fmt.Sprintf(
+			"Shop %s %s (%s) from %s. Quality construction supplies with competitive pricing in the Philippines.",
+			product.BrandName,
+			product.Name,
+			product.Serial,
+			product.BrandName,
+		)
+	} else if len(description) > 155 {
+		description = description[:152] + "..."
+	}
+
+	keywords := strings.Join([]string{
+		product.BrandName,
+		product.Name,
+		product.Serial,
+		product.ProductCategory,
+		product.ProductSubcategory,
+		"c-choice",
+		"construction supplies",
+		"philippines",
+	}, ", ")
+
+	ogImage := imageURL
+	if ogImage == "" {
+		ogImage = DefaultOGImage
+	}
+
+	return ProductMeta{
+		Title:          title,
+		Description:    description,
+		CanonicalURL:   canonicalURL,
+		OGImage:        ogImage,
+		OGType:         ProductOGType,
+		Robots:         ProductRobots,
+		Keywords:       keywords,
+		TwitterCard:    ProductTwitterCard,
+		PriceAmount:    priceAmount,
+		PriceCurrency:  priceCurrency,
+		StructuredData: BuildProductStructuredData(product, canonicalURL, ogImage, priceAmount, priceCurrency, homeURL),
+	}
+}
+
+func BuildProductStructuredData(
+	product Product,
+	canonicalURL string,
+	imageURL string,
+	priceAmount string,
+	priceCurrency string,
+	siteBaseURL string,
+) string {
+	type brand struct {
+		Type string `json:"@type"`
+		Name string `json:"name"`
+	}
+	type offer struct {
+		Type          string `json:"@type"`
+		URL           string `json:"url"`
+		PriceCurrency string `json:"priceCurrency"`
+		Price         string `json:"price"`
+		Availability  string `json:"availability"`
+		ItemCondition string `json:"itemCondition"`
+	}
+	type breadcrumbItem struct {
+		Type     string `json:"@type"`
+		Position int    `json:"position"`
+		Name     string `json:"name"`
+		Item     string `json:"item,omitempty"`
+	}
+	type breadcrumbList struct {
+		Type     string           `json:"@type"`
+		ItemList []breadcrumbItem `json:"itemListElement"`
+	}
+	type productSchema struct {
+		Context     string         `json:"@context"`
+		Type        string         `json:"@type"`
+		Name        string         `json:"name"`
+		Description string         `json:"description,omitempty"`
+		Image       []string       `json:"image,omitempty"`
+		SKU         string         `json:"sku"`
+		Brand       brand          `json:"brand"`
+		Offers      offer          `json:"offers"`
+		Breadcrumb  breadcrumbList `json:"breadcrumb"`
+	}
+
+	description := strings.TrimSpace(product.Description)
+	images := []string{}
+	if imageURL != "" {
+		images = append(images, imageURL)
+	}
+
+	items := []breadcrumbItem{
+		{Type: "ListItem", Position: 1, Name: "Home", Item: strings.TrimSuffix(siteBaseURL, "/") + "/"},
+	}
+	position := 2
+	if product.ProductCategory != "" {
+		items = append(items, breadcrumbItem{
+			Type:     "ListItem",
+			Position: position,
+			Name:     product.ProductCategory,
+		})
+		position++
+	}
+	if product.ProductSubcategory != "" {
+		items = append(items, breadcrumbItem{
+			Type:     "ListItem",
+			Position: position,
+			Name:     product.ProductSubcategory,
+		})
+		position++
+	}
+	items = append(items, breadcrumbItem{
+		Type:     "ListItem",
+		Position: position,
+		Name:     product.Name,
+		Item:     canonicalURL,
+	})
+
+	schema := productSchema{
+		Context:     "https://schema.org",
+		Type:        "Product",
+		Name:        fmt.Sprintf("%s %s", product.BrandName, product.Name),
+		Description: description,
+		Image:       images,
+		SKU:         product.Serial,
+		Brand:       brand{Type: "Brand", Name: product.BrandName},
+		Offers: offer{
+			Type:          "Offer",
+			URL:           canonicalURL,
+			PriceCurrency: priceCurrency,
+			Price:         priceAmount,
+			Availability:  "https://schema.org/InStock",
+			ItemCondition: "https://schema.org/NewCondition",
+		},
+		Breadcrumb: breadcrumbList{
+			Type:     "BreadcrumbList",
+			ItemList: items,
+		},
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}

--- a/internal/seo/seo_test.go
+++ b/internal/seo/seo_test.go
@@ -1,0 +1,195 @@
+package seo
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeXML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "ampersand", input: "a&b", want: "a&amp;b"},
+		{name: "less than", input: "a<b", want: "a&lt;b"},
+		{name: "greater than", input: "a>b", want: "a&gt;b"},
+		{name: "quotes", input: `a"b'c`, want: "a&quot;b&apos;c"},
+		{name: "url with query", input: "https://example.com?a=1&b=2", want: "https://example.com?a=1&amp;b=2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EscapeXML(tt.input))
+		})
+	}
+}
+
+func TestInjectSitemapLine(t *testing.T) {
+	content := "User-agent: *\nAllow: /\n\n# __SITEMAP__\n"
+	got := InjectSitemapLine(content, "https://cchoice.shop/sitemap.xml")
+	assert.Equal(t, "User-agent: *\nAllow: /\n\nSitemap: https://cchoice.shop/sitemap.xml\n", got)
+}
+
+func TestProductCanonicalURL(t *testing.T) {
+	assert.Equal(
+		t,
+		"https://cchoice.shop/product/bosch-drill-123",
+		ProductCanonicalURL("https://cchoice.shop", "bosch-drill-123"),
+	)
+}
+
+func TestWriteSitemapURL(t *testing.T) {
+	var buf bytes.Buffer
+
+	WriteSitemapURL(&buf, SitemapEntry{
+		Loc:        "https://cchoice.shop/product/test?a=1&b=2",
+		LastMod:    time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC),
+		ChangeFreq: "weekly",
+		Priority:   "0.8",
+	})
+
+	got := buf.String()
+	assert.Contains(t, got, "<loc>https://cchoice.shop/product/test?a=1&amp;b=2</loc>")
+	assert.Contains(t, got, "<lastmod>2026-07-05</lastmod>")
+	assert.Contains(t, got, "<changefreq>weekly</changefreq>")
+	assert.Contains(t, got, "<priority>0.8</priority>")
+}
+
+func TestBuildSitemapXML(t *testing.T) {
+	products := []SitemapEntry{
+		{
+			Loc:        "https://cchoice.shop/product/bosch-drill",
+			LastMod:    time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			ChangeFreq: "weekly",
+			Priority:   "0.8",
+		},
+	}
+
+	got := BuildSitemapXML("https://cchoice.shop", products)
+
+	assert.True(t, strings.HasPrefix(got, `<?xml version="1.0" encoding="UTF-8"?>`))
+	assert.Contains(t, got, `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	assert.Contains(t, got, "<loc>https://cchoice.shop</loc>")
+	assert.Contains(t, got, "<loc>https://cchoice.shop/product/bosch-drill</loc>")
+	assert.Contains(t, got, "<lastmod>2026-07-01</lastmod>")
+	assert.Contains(t, got, `</urlset>`)
+}
+
+func TestGenerateProductMeta(t *testing.T) {
+	product := Product{
+		BrandName:          "Bosch",
+		Name:               "Hammer Drill",
+		Serial:             "GBH2-28",
+		Description:        "Professional hammer drill for heavy-duty work.",
+		ProductCategory:    "Power Tools",
+		ProductSubcategory: "Drills",
+	}
+
+	meta := GenerateProductMeta(
+		product,
+		"https://cchoice.shop/product/bosch-hammer-drill-gbh2-28",
+		"https://cchoice.shop",
+		"https://cdn.example.com/product.webp",
+		"12999.00",
+		"PHP",
+	)
+
+	assert.Equal(t, "Bosch Hammer Drill (GBH2-28) - Price, Specs, Buy Online | C-Choice", meta.Title)
+	assert.Equal(t, "Professional hammer drill for heavy-duty work.", meta.Description)
+	assert.Equal(t, "https://cchoice.shop/product/bosch-hammer-drill-gbh2-28", meta.CanonicalURL)
+	assert.Equal(t, ProductOGType, meta.OGType)
+	assert.Equal(t, ProductRobots, meta.Robots)
+	assert.Equal(t, ProductTwitterCard, meta.TwitterCard)
+	assert.Contains(t, meta.Keywords, "Bosch")
+	assert.Contains(t, meta.Keywords, "Power Tools")
+	assert.NotEmpty(t, meta.StructuredData)
+}
+
+func TestGenerateProductMeta_TruncatesLongDescription(t *testing.T) {
+	longDescription := strings.Repeat("a", 200)
+	product := Product{
+		BrandName:   "Bosch",
+		Name:        "Hammer Drill",
+		Serial:      "GBH2-28",
+		Description: longDescription,
+	}
+
+	meta := GenerateProductMeta(
+		product,
+		"https://cchoice.shop/product/slug",
+		"https://cchoice.shop",
+		"",
+		"100.00",
+		"PHP",
+	)
+
+	assert.Len(t, meta.Description, 155)
+	assert.True(t, strings.HasSuffix(meta.Description, "..."))
+}
+
+func TestGenerateProductMeta_FallbackDescription(t *testing.T) {
+	product := Product{
+		BrandName: "Bosch",
+		Name:      "Hammer Drill",
+		Serial:    "GBH2-28",
+	}
+
+	meta := GenerateProductMeta(
+		product,
+		"https://cchoice.shop/product/slug",
+		"https://cchoice.shop",
+		"",
+		"100.00",
+		"PHP",
+	)
+
+	assert.Contains(t, meta.Description, "Shop Bosch Hammer Drill (GBH2-28)")
+	assert.Equal(t, DefaultOGImage, meta.OGImage)
+}
+
+func TestBuildProductStructuredData(t *testing.T) {
+	product := Product{
+		BrandName:          "Bosch",
+		Name:               "Hammer Drill",
+		Serial:             "GBH2-28",
+		Description:        "Heavy-duty drill",
+		ProductCategory:    "Power Tools",
+		ProductSubcategory: "Drills",
+	}
+
+	raw := BuildProductStructuredData(
+		product,
+		"https://cchoice.shop/product/bosch-hammer-drill",
+		"https://cdn.example.com/product.webp",
+		"12999.00",
+		"PHP",
+		"https://cchoice.shop",
+	)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(raw), &payload))
+
+	assert.Equal(t, "https://schema.org", payload["@context"])
+	assert.Equal(t, "Product", payload["@type"])
+	assert.Equal(t, "Bosch Hammer Drill", payload["name"])
+	assert.Equal(t, "GBH2-28", payload["sku"])
+
+	offers, ok := payload["offers"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "12999.00", offers["price"])
+	assert.Equal(t, "PHP", offers["priceCurrency"])
+	assert.Equal(t, "https://cchoice.shop/product/bosch-hammer-drill", offers["url"])
+
+	breadcrumb, ok := payload["breadcrumb"].(map[string]any)
+	require.True(t, ok)
+	items, ok := breadcrumb["itemListElement"].([]any)
+	require.True(t, ok)
+	assert.GreaterOrEqual(t, len(items), 4)
+}

--- a/internal/server/products.go
+++ b/internal/server/products.go
@@ -1,15 +1,17 @@
 package server
 
 import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+
+	"cchoice/cmd/web/components"
 	compproduct "cchoice/cmd/web/components/product"
 	"cchoice/internal/encode"
 	"cchoice/internal/errs"
 	"cchoice/internal/logs"
 	"cchoice/internal/utils"
-	"net/http"
-
-	"github.com/go-chi/chi/v5"
-	"go.uber.org/zap"
 )
 
 func AddProductHandlers(s *Server, r chi.Router) {
@@ -23,24 +25,22 @@ func (s *Server) productPageHandler(w http.ResponseWriter, r *http.Request) {
 
 	slug := chi.URLParam(r, "slug")
 	if slug == "" {
-		redirectHX(w, r, utils.URLWithError(page, errs.ErrNotFound.Error()))
+		s.renderProductNotFound(w, r, page)
 		return
 	}
 
 	productData, err := s.services.product.GetForPage(ctx, slug)
 	if err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err), zap.String("slug", slug))
-		redirectHX(w, r, utils.URLWithError(page, err.Error()))
+		s.renderProductNotFound(w, r, page)
 		return
 	}
 
 	decodedProductID := s.encoder.Decode(productData.ProductID)
 	if decodedProductID == encode.INVALID {
-		redirectHX(w, r, utils.URLWithError(page, errs.ErrNotFound.Error()))
+		s.renderProductNotFound(w, r, page)
 		return
 	}
-
-	// TODO: Query related products by category
 
 	if err := compproduct.ProductPage(*productData).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
@@ -51,5 +51,19 @@ func (s *Server) productPageHandler(w http.ResponseWriter, r *http.Request) {
 		)
 		redirectHX(w, r, utils.URLWithError(page, err.Error()))
 		return
+	}
+}
+
+func (s *Server) renderProductNotFound(w http.ResponseWriter, r *http.Request, fallbackURL string) {
+	if isHTMX(r) {
+		redirectHX(w, r, utils.URLWithError(fallbackURL, errs.ErrNotFound.Error()))
+		return
+	}
+
+	ctx := r.Context()
+	w.WriteHeader(http.StatusNotFound)
+	if err := components.NotPage().Render(ctx, w); err != nil {
+		logs.LogCtx(ctx).Error("[Product Page Handler]", zap.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -185,6 +185,7 @@ func (s *Server) registerAllRoutes(r chi.Router) {
 
 	AddProductCategoriesHandlers(s, r)
 	AddProductHandlers(s, r)
+	AddSEOHandlers(s, r)
 	AddBrandsHandlers(s, r)
 	AddCartsHandlers(s, r)
 	AddOrdersHandlers(s, r)

--- a/internal/server/seo.go
+++ b/internal/server/seo.go
@@ -1,14 +1,12 @@
 package server
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"cchoice/internal/logs"
+	"cchoice/internal/seo"
 	"cchoice/internal/utils"
 
 	"github.com/go-chi/chi/v5"
@@ -39,8 +37,7 @@ func (s *Server) robotsTxtHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sitemapLine := fmt.Sprintf("Sitemap: %s", utils.SiteURL("/sitemap.xml"))
-	body := strings.Replace(string(content), "# __SITEMAP__", sitemapLine, 1)
+	body := seo.InjectSitemapLine(string(content), utils.SiteURL("/sitemap.xml"))
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
@@ -60,12 +57,7 @@ func (s *Server) sitemapHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var buf bytes.Buffer
-	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
-	buf.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
-
-	writeSitemapURL(&buf, utils.SiteURL("/"), time.Now().UTC(), "daily", "1.0")
-
+	entries := make([]seo.SitemapEntry, 0, len(products))
 	for _, product := range products {
 		if !product.Slug.Valid || product.Slug.String == "" {
 			continue
@@ -74,38 +66,19 @@ func (s *Server) sitemapHandler(w http.ResponseWriter, r *http.Request) {
 		if lastMod.IsZero() {
 			lastMod = time.Now().UTC()
 		}
-		writeSitemapURL(
-			&buf,
-			utils.SiteURL("/product/"+product.Slug.String),
-			lastMod.UTC(),
-			"weekly",
-			"0.8",
-		)
+		entries = append(entries, seo.SitemapEntry{
+			Loc:        utils.SiteURL("/product/" + product.Slug.String),
+			LastMod:    lastMod.UTC(),
+			ChangeFreq: "weekly",
+			Priority:   "0.8",
+		})
 	}
 
-	buf.WriteString(`</urlset>`)
+	body := seo.BuildSitemapXML(utils.SiteURL("/"), entries)
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
-	if _, err := w.Write(buf.Bytes()); err != nil {
+	if _, err := w.Write([]byte(body)); err != nil {
 		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
 	}
-}
-
-func writeSitemapURL(buf *bytes.Buffer, loc string, lastMod time.Time, changefreq string, priority string) {
-	fmt.Fprintf(buf, "<url><loc>%s</loc>", escapeXML(loc))
-	fmt.Fprintf(buf, "<lastmod>%s</lastmod>", lastMod.Format("2006-01-02"))
-	fmt.Fprintf(buf, "<changefreq>%s</changefreq>", changefreq)
-	fmt.Fprintf(buf, "<priority>%s</priority></url>", priority)
-}
-
-func escapeXML(s string) string {
-	replacer := strings.NewReplacer(
-		"&", "&amp;",
-		"<", "&lt;",
-		">", "&gt;",
-		"'", "&apos;",
-		"\"", "&quot;",
-	)
-	return replacer.Replace(s)
 }

--- a/internal/server/seo.go
+++ b/internal/server/seo.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"cchoice/internal/logs"
+	"cchoice/internal/utils"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+)
+
+func AddSEOHandlers(s *Server, r chi.Router) {
+	r.Get("/robots.txt", s.robotsTxtHandler)
+	r.Get("/sitemap.xml", s.sitemapHandler)
+}
+
+func (s *Server) robotsTxtHandler(w http.ResponseWriter, r *http.Request) {
+	const logtag = "[Robots Handler]"
+	ctx := r.Context()
+
+	file, err := s.staticFS.Open("robots.txt")
+	if err != nil {
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	sitemapLine := fmt.Sprintf("Sitemap: %s", utils.SiteURL("/sitemap.xml"))
+	body := strings.Replace(string(content), "# __SITEMAP__", sitemapLine, 1)
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	if _, err := w.Write([]byte(body)); err != nil {
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
+	}
+}
+
+func (s *Server) sitemapHandler(w http.ResponseWriter, r *http.Request) {
+	const logtag = "[Sitemap Handler]"
+	ctx := r.Context()
+
+	products, err := s.services.product.ListActiveProductSlugs(ctx)
+	if err != nil {
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	buf.WriteString(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+
+	writeSitemapURL(&buf, utils.SiteURL("/"), time.Now().UTC(), "daily", "1.0")
+
+	for _, product := range products {
+		if !product.Slug.Valid || product.Slug.String == "" {
+			continue
+		}
+		lastMod := product.UpdatedAt
+		if lastMod.IsZero() {
+			lastMod = time.Now().UTC()
+		}
+		writeSitemapURL(
+			&buf,
+			utils.SiteURL("/product/"+product.Slug.String),
+			lastMod.UTC(),
+			"weekly",
+			"0.8",
+		)
+	}
+
+	buf.WriteString(`</urlset>`)
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		logs.LogCtx(ctx).Error(logtag, zap.Error(err))
+	}
+}
+
+func writeSitemapURL(buf *bytes.Buffer, loc string, lastMod time.Time, changefreq string, priority string) {
+	fmt.Fprintf(buf, "<url><loc>%s</loc>", escapeXML(loc))
+	fmt.Fprintf(buf, "<lastmod>%s</lastmod>", lastMod.Format("2006-01-02"))
+	fmt.Fprintf(buf, "<changefreq>%s</changefreq>", changefreq)
+	fmt.Fprintf(buf, "<priority>%s</priority></url>", priority)
+}
+
+func escapeXML(s string) string {
+	replacer := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		"'", "&apos;",
+		"\"", "&quot;",
+	)
+	return replacer.Replace(s)
+}

--- a/internal/services/products.go
+++ b/internal/services/products.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"cchoice/internal/enums"
 	"cchoice/internal/errs"
 	"cchoice/internal/logs"
+	"cchoice/internal/seo"
 	"cchoice/internal/utils"
 )
 
@@ -917,159 +917,35 @@ func (s *ProductService) GenerateMeta(
 	priceAmount string,
 	priceCurrency string,
 ) models.ProductsMeta {
-	title := fmt.Sprintf(
-		"%s %s (%s) - Price, Specs, Buy Online | C-Choice",
-		product.BrandName,
-		product.Name,
-		product.Serial,
+	meta := seo.GenerateProductMeta(
+		seo.Product{
+			BrandName:          product.BrandName,
+			Name:               product.Name,
+			Serial:             product.Serial,
+			Description:        product.Description.String,
+			ProductCategory:    product.ProductCategory,
+			ProductSubcategory: product.ProductSubcategory,
+		},
+		utils.SiteURL("/product/"+slug),
+		utils.SiteURL("/"),
+		imageURL,
+		priceAmount,
+		priceCurrency,
 	)
 
-	description := strings.TrimSpace(product.Description.String)
-	if description == "" {
-		description = fmt.Sprintf(
-			"Shop %s %s (%s) from %s. Quality construction supplies with competitive pricing in the Philippines.",
-			product.BrandName,
-			product.Name,
-			product.Serial,
-			product.BrandName,
-		)
-	} else if len(description) > 155 {
-		description = description[:152] + "..."
-	}
-
-	keywords := strings.Join([]string{
-		product.BrandName,
-		product.Name,
-		product.Serial,
-		product.ProductCategory,
-		product.ProductSubcategory,
-		"c-choice",
-		"construction supplies",
-		"philippines",
-	}, ", ")
-
-	canonicalURL := utils.SiteURL("/product/" + slug)
-	ogImage := imageURL
-	if ogImage == "" {
-		ogImage = models.DefaultSiteSEO().OGImage
-	}
-
 	return models.ProductsMeta{
-		Title:          title,
-		Content:        description,
-		CanonicalURL:   canonicalURL,
-		OGImage:        ogImage,
-		OGType:         "product",
-		Robots:         "index, follow, max-image-preview:large",
-		Keywords:       keywords,
-		TwitterCard:    "summary_large_image",
-		PriceAmount:    priceAmount,
-		PriceCurrency:  priceCurrency,
-		StructuredData: buildProductStructuredData(product, canonicalURL, ogImage, priceAmount, priceCurrency),
+		Title:          meta.Title,
+		Content:        meta.Description,
+		CanonicalURL:   meta.CanonicalURL,
+		OGImage:        meta.OGImage,
+		OGType:         meta.OGType,
+		Robots:         meta.Robots,
+		Keywords:       meta.Keywords,
+		TwitterCard:    meta.TwitterCard,
+		PriceAmount:    meta.PriceAmount,
+		PriceCurrency:  meta.PriceCurrency,
+		StructuredData: meta.StructuredData,
 	}
-}
-
-func buildProductStructuredData(
-	product *queries.GetProductPageRow,
-	canonicalURL string,
-	imageURL string,
-	priceAmount string,
-	priceCurrency string,
-) string {
-	type brand struct {
-		Type string `json:"@type"`
-		Name string `json:"name"`
-	}
-	type offer struct {
-		Type         string `json:"@type"`
-		URL          string `json:"url"`
-		PriceCurrency string `json:"priceCurrency"`
-		Price        string `json:"price"`
-		Availability string `json:"availability"`
-		ItemCondition string `json:"itemCondition"`
-	}
-	type breadcrumbItem struct {
-		Type     string `json:"@type"`
-		Position int    `json:"position"`
-		Name     string `json:"name"`
-		Item     string `json:"item,omitempty"`
-	}
-	type breadcrumbList struct {
-		Type     string           `json:"@type"`
-		ItemList []breadcrumbItem `json:"itemListElement"`
-	}
-	type productSchema struct {
-		Context     string         `json:"@context"`
-		Type        string         `json:"@type"`
-		Name        string         `json:"name"`
-		Description string         `json:"description,omitempty"`
-		Image       []string       `json:"image,omitempty"`
-		SKU         string         `json:"sku"`
-		Brand       brand          `json:"brand"`
-		Offers      offer          `json:"offers"`
-		Breadcrumb  breadcrumbList `json:"breadcrumb"`
-	}
-
-	description := strings.TrimSpace(product.Description.String)
-	images := []string{}
-	if imageURL != "" {
-		images = append(images, imageURL)
-	}
-
-	items := []breadcrumbItem{
-		{Type: "ListItem", Position: 1, Name: "Home", Item: utils.SiteURL("/")},
-	}
-	position := 2
-	if product.ProductCategory != "" {
-		items = append(items, breadcrumbItem{
-			Type:     "ListItem",
-			Position: position,
-			Name:     product.ProductCategory,
-		})
-		position++
-	}
-	if product.ProductSubcategory != "" {
-		items = append(items, breadcrumbItem{
-			Type:     "ListItem",
-			Position: position,
-			Name:     product.ProductSubcategory,
-		})
-		position++
-	}
-	items = append(items, breadcrumbItem{
-		Type:     "ListItem",
-		Position: position,
-		Name:     product.Name,
-		Item:     canonicalURL,
-	})
-
-	schema := productSchema{
-		Context:     "https://schema.org",
-		Type:        "Product",
-		Name:        fmt.Sprintf("%s %s", product.BrandName, product.Name),
-		Description: description,
-		Image:       images,
-		SKU:         product.Serial,
-		Brand:       brand{Type: "Brand", Name: product.BrandName},
-		Offers: offer{
-			Type:          "Offer",
-			URL:           canonicalURL,
-			PriceCurrency: priceCurrency,
-			Price:         priceAmount,
-			Availability:  "https://schema.org/InStock",
-			ItemCondition: "https://schema.org/NewCondition",
-		},
-		Breadcrumb: breadcrumbList{
-			Type:     "BreadcrumbList",
-			ItemList: items,
-		},
-	}
-
-	data, err := json.Marshal(schema)
-	if err != nil {
-		return ""
-	}
-	return string(data)
 }
 
 func (s *ProductService) ListActiveProductSlugs(ctx context.Context) ([]queries.ListActiveProductSlugsRow, error) {

--- a/internal/services/products.go
+++ b/internal/services/products.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -790,8 +791,21 @@ func (s *ProductService) GetForPage(ctx context.Context, slug string) (*models.P
 		models.ProductSpec{Label: "Weight", Value: utils.ToWeightDisplay(row.Weight, row.WeightUnit)},
 	}
 
+	relatedProducts, err := s.getRelatedProducts(ctx, row.CategoryID, row.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get related products: %w", err)
+	}
+
+	priceAmount, priceCurrency := utils.SchemaPrice(salePrice, saleCurrency)
+	productSlug := slug
+	if row.Slug.Valid && row.Slug.String != "" {
+		productSlug = row.Slug.String
+	}
+	meta := s.GenerateMeta(&row, productSlug, cdnURL1280, priceAmount, priceCurrency)
+
 	return &models.ProductPageData{
-		Meta:                       s.GenerateMeta(&row),
+		Meta:                       meta,
+		Slug:                       productSlug,
 		ProductID:                  s.encoder.Encode(row.ID),
 		Serial:                     row.Serial,
 		Name:                       row.Name,
@@ -815,29 +829,251 @@ func (s *ProductService) GetForPage(ctx context.Context, slug string) (*models.P
 		Colours:                    colours,
 		Sizes:                      sizes,
 		Specs:                      specs,
+		RelatedProducts:            relatedProducts,
 	}, nil
 }
 
-func (s *ProductService) GenerateMeta(product *queries.GetProductPageRow) models.ProductsMeta {
-	title := fmt.Sprintf(
-		"%s %s %s (%s) - Price, Specs, Buy Online",
-		product.BrandName,
-		product.Name,
-		product.Power,
-		product.Serial,
-	)
-	content := fmt.Sprintf(
-		"Buy %s %s %s (%s). Power Tool. Durable. Quality. Best Prices in the Philippines. Free Shipping Available. %s",
-		product.BrandName,
-		product.Name,
-		product.Power,
-		product.Serial,
-		product.Description.String,
-	)
-	return models.ProductsMeta{
-		Title:   title,
-		Content: content,
+func (s *ProductService) getRelatedProducts(
+	ctx context.Context,
+	categoryID sql.NullInt64,
+	productID int64,
+) ([]models.RelatedProduct, error) {
+	if !categoryID.Valid || categoryID.Int64 == 0 {
+		return nil, nil
 	}
+
+	rows, err := s.dbRO.GetQueries().GetRelatedProductsByCategory(ctx, queries.GetRelatedProductsByCategoryParams{
+		CategoryID: categoryID.Int64,
+		ID:         productID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	related := make([]models.RelatedProduct, 0, len(rows))
+	for _, row := range rows {
+		if !row.Slug.Valid || row.Slug.String == "" {
+			continue
+		}
+
+		origPrice := utils.NewMoney(row.UnitPriceWithVat, row.UnitPriceWithVatCurrency)
+		var salePrice int64
+		var saleCurrency string
+		if row.IsOnSale == 1 {
+			if sp, ok := row.SalePriceWithVat.(int64); ok {
+				salePrice = sp
+			} else {
+				salePrice = row.UnitPriceWithVat
+			}
+			if sc, ok := row.SalePriceWithVatCurrency.(string); ok {
+				saleCurrency = sc
+			} else {
+				saleCurrency = row.UnitPriceWithVatCurrency
+			}
+		} else {
+			salePrice = row.UnitPriceWithVat
+			saleCurrency = row.UnitPriceWithVatCurrency
+		}
+
+		discountedPrice := utils.NewMoney(salePrice, saleCurrency)
+		_, _, discountPercentage := utils.GetOrigAndDiscounted(
+			row.IsOnSale,
+			row.UnitPriceWithVat,
+			row.UnitPriceWithVatCurrency,
+			sql.NullInt64{Int64: salePrice, Valid: row.IsOnSale == 1},
+			sql.NullString{String: saleCurrency, Valid: row.IsOnSale == 1},
+		)
+
+		cdnURL := row.CdnUrl
+		if cdnURL == "" {
+			cdnURL = s.getCDNURL(row.ThumbnailPath)
+		}
+		cdnURL1280 := row.CdnUrlThumbnail
+		if cdnURL1280 == "" {
+			cdnURL1280 = s.getCDNURL(constants.ToPath1280(row.ThumbnailPath))
+		}
+
+		related = append(related, models.RelatedProduct{
+			ProductID:          s.encoder.Encode(row.ID),
+			Slug:               row.Slug.String,
+			Name:               row.Name,
+			Serial:             row.Serial,
+			BrandName:          row.BrandName,
+			CDNURL:             cdnURL,
+			CDNURL1280:         cdnURL1280,
+			OrigPriceDisplay:   origPrice.Display(),
+			PriceDisplay:       discountedPrice.Display(),
+			DiscountPercentage: discountPercentage,
+		})
+	}
+
+	return related, nil
+}
+
+func (s *ProductService) GenerateMeta(
+	product *queries.GetProductPageRow,
+	slug string,
+	imageURL string,
+	priceAmount string,
+	priceCurrency string,
+) models.ProductsMeta {
+	title := fmt.Sprintf(
+		"%s %s (%s) - Price, Specs, Buy Online | C-Choice",
+		product.BrandName,
+		product.Name,
+		product.Serial,
+	)
+
+	description := strings.TrimSpace(product.Description.String)
+	if description == "" {
+		description = fmt.Sprintf(
+			"Shop %s %s (%s) from %s. Quality construction supplies with competitive pricing in the Philippines.",
+			product.BrandName,
+			product.Name,
+			product.Serial,
+			product.BrandName,
+		)
+	} else if len(description) > 155 {
+		description = description[:152] + "..."
+	}
+
+	keywords := strings.Join([]string{
+		product.BrandName,
+		product.Name,
+		product.Serial,
+		product.ProductCategory,
+		product.ProductSubcategory,
+		"c-choice",
+		"construction supplies",
+		"philippines",
+	}, ", ")
+
+	canonicalURL := utils.SiteURL("/product/" + slug)
+	ogImage := imageURL
+	if ogImage == "" {
+		ogImage = models.DefaultSiteSEO().OGImage
+	}
+
+	return models.ProductsMeta{
+		Title:          title,
+		Content:        description,
+		CanonicalURL:   canonicalURL,
+		OGImage:        ogImage,
+		OGType:         "product",
+		Robots:         "index, follow, max-image-preview:large",
+		Keywords:       keywords,
+		TwitterCard:    "summary_large_image",
+		PriceAmount:    priceAmount,
+		PriceCurrency:  priceCurrency,
+		StructuredData: buildProductStructuredData(product, canonicalURL, ogImage, priceAmount, priceCurrency),
+	}
+}
+
+func buildProductStructuredData(
+	product *queries.GetProductPageRow,
+	canonicalURL string,
+	imageURL string,
+	priceAmount string,
+	priceCurrency string,
+) string {
+	type brand struct {
+		Type string `json:"@type"`
+		Name string `json:"name"`
+	}
+	type offer struct {
+		Type         string `json:"@type"`
+		URL          string `json:"url"`
+		PriceCurrency string `json:"priceCurrency"`
+		Price        string `json:"price"`
+		Availability string `json:"availability"`
+		ItemCondition string `json:"itemCondition"`
+	}
+	type breadcrumbItem struct {
+		Type     string `json:"@type"`
+		Position int    `json:"position"`
+		Name     string `json:"name"`
+		Item     string `json:"item,omitempty"`
+	}
+	type breadcrumbList struct {
+		Type     string           `json:"@type"`
+		ItemList []breadcrumbItem `json:"itemListElement"`
+	}
+	type productSchema struct {
+		Context     string         `json:"@context"`
+		Type        string         `json:"@type"`
+		Name        string         `json:"name"`
+		Description string         `json:"description,omitempty"`
+		Image       []string       `json:"image,omitempty"`
+		SKU         string         `json:"sku"`
+		Brand       brand          `json:"brand"`
+		Offers      offer          `json:"offers"`
+		Breadcrumb  breadcrumbList `json:"breadcrumb"`
+	}
+
+	description := strings.TrimSpace(product.Description.String)
+	images := []string{}
+	if imageURL != "" {
+		images = append(images, imageURL)
+	}
+
+	items := []breadcrumbItem{
+		{Type: "ListItem", Position: 1, Name: "Home", Item: utils.SiteURL("/")},
+	}
+	position := 2
+	if product.ProductCategory != "" {
+		items = append(items, breadcrumbItem{
+			Type:     "ListItem",
+			Position: position,
+			Name:     product.ProductCategory,
+		})
+		position++
+	}
+	if product.ProductSubcategory != "" {
+		items = append(items, breadcrumbItem{
+			Type:     "ListItem",
+			Position: position,
+			Name:     product.ProductSubcategory,
+		})
+		position++
+	}
+	items = append(items, breadcrumbItem{
+		Type:     "ListItem",
+		Position: position,
+		Name:     product.Name,
+		Item:     canonicalURL,
+	})
+
+	schema := productSchema{
+		Context:     "https://schema.org",
+		Type:        "Product",
+		Name:        fmt.Sprintf("%s %s", product.BrandName, product.Name),
+		Description: description,
+		Image:       images,
+		SKU:         product.Serial,
+		Brand:       brand{Type: "Brand", Name: product.BrandName},
+		Offers: offer{
+			Type:          "Offer",
+			URL:           canonicalURL,
+			PriceCurrency: priceCurrency,
+			Price:         priceAmount,
+			Availability:  "https://schema.org/InStock",
+			ItemCondition: "https://schema.org/NewCondition",
+		},
+		Breadcrumb: breadcrumbList{
+			Type:     "BreadcrumbList",
+			ItemList: items,
+		},
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func (s *ProductService) ListActiveProductSlugs(ctx context.Context) ([]queries.ListActiveProductSlugsRow, error) {
+	return s.dbRO.GetQueries().ListActiveProductSlugs(ctx)
 }
 
 func (s *ProductService) ListForQuotations(ctx context.Context) ([]queries.ListProductsForQuotationsRow, error) {

--- a/internal/utils/money.go
+++ b/internal/utils/money.go
@@ -61,3 +61,12 @@ func GetDiscountAmount(
 	discount := unitPriceWithVat - salePriceWithVat.Int64
 	return NewMoney(discount, constants.PHP)
 }
+
+func SchemaPrice(amount int64, currency string) (string, string) {
+	dec := decimal.MustNew(amount, constants.DecimalScale)
+	f, ok := dec.Float64()
+	if !ok {
+		return "0.00", currency
+	}
+	return fmt.Sprintf("%.2f", f), currency
+}

--- a/internal/utils/urls.go
+++ b/internal/utils/urls.go
@@ -4,10 +4,27 @@ import (
 	"cchoice/internal/conf"
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 func FullURL(path string) string {
-	return conf.Conf().Server.Address + URL(path)
+	return siteBaseURL() + URL(path)
+}
+
+func SiteURL(path string) string {
+	return siteBaseURL() + URL(path)
+}
+
+func siteBaseURL() string {
+	base := strings.TrimSuffix(conf.Conf().Server.Address, "/")
+	if strings.HasPrefix(base, "http://") || strings.HasPrefix(base, "https://") {
+		return base
+	}
+	scheme := "https://"
+	if conf.Conf().IsLocal() {
+		scheme = "http://"
+	}
+	return scheme + base
 }
 
 func URL(path string) string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Describe your changes

Product pages were partially optimized for SEO but still inherited harmful global defaults (wrong canonical domain, `noimageindex`, generic Open Graph tags) and lacked structured data and discovery endpoints.

This PR makes product pages indexable and discoverable:

- **Per-product head metadata** — canonical URL, `index, follow, max-image-preview:large`, product-specific title/description/keywords, Open Graph (`product` type), and Twitter large-image cards
- **JSON-LD structured data** — `Product`, `Offer`, and `BreadcrumbList` schema for rich search results
- **Sitemap & robots** — dynamic `/sitemap.xml` listing active product slugs; `/robots.txt` served from static assets with injected sitemap URL; admin/customer/auth paths disallowed
- **HTTP semantics** — missing/invalid product slugs return `404` (instead of redirecting to home) for crawlers
- **Internal linking** — related products are loaded by category and linked via slugs
- **Site-wide canonical fix** — default head SEO now uses configured `ADDRESS` via `utils.SiteURL()` instead of hardcoded `primary.shop`
- **SEO unit tests** — pure SEO logic lives in `internal/seo` with tests that avoid the govips init chain

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have run the unit tests locally.
- [x] If it is a core feature, I have added thorough unit/integration tests.
- [x] I have accomplished the PR: assignee(s), labels, reviewers, and more.

## Picture or recording of local testing

Built successfully with `go build -tags="fts5,staticfs,imageprocessing"`.
SEO tests: `go test ./internal/seo/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c4b6c40-862c-4f35-a999-9aaccbd07d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4b6c40-862c-4f35-a999-9aaccbd07d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

