### PR TITLE
Feature: Link orders to customers and prefill cart shipping

### DIFF
--- a/cmd/web/components/cart/index.templ
+++ b/cmd/web/components/cart/index.templ
@@ -52,7 +52,7 @@ templ CPointsLoginBanner() {
 	</div>
 }
 
-templ CartPageBody(summaryContent templ.Component, showCPointsBanner bool) {
+templ CartPageBody(summaryContent templ.Component, showCPointsBanner bool, shippingPrefill models.CartShippingPrefill) {
 	<body class="h-screen m-0 p-0 overflow-x-hidden custom-scrollbar">
 		@common.DevRibbon()
 		@common.ErrorBanner()
@@ -89,7 +89,7 @@ templ CartPageBody(summaryContent templ.Component, showCPointsBanner bool) {
 								id="cart-shipping-content"
 								class="flex flex-col gap-1 p-2"
 							>
-								@CartSubcard("shipping-address-select", "Shipping Information", ShippingAddressSelect())
+								@CartSubcard("shipping-address-select", "Shipping Information", ShippingAddressSelect(shippingPrefill))
 							</div>
 						</div>
 					</div>

--- a/cmd/web/components/cart/index_templ.go
+++ b/cmd/web/components/cart/index_templ.go
@@ -99,7 +99,7 @@ func CPointsLoginBanner() templ.Component {
 		var templ_7745c5c3_Var3 templ.SafeURL
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/customer"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 38, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 38, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -112,7 +112,7 @@ func CPointsLoginBanner() templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(utils.URL("/customer/register"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 45, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 45, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -126,7 +126,7 @@ func CPointsLoginBanner() templ.Component {
 	})
 }
 
-func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.Component {
+func CartPageBody(summaryContent templ.Component, showCPointsBanner bool, shippingPrefill models.CartShippingPrefill) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -184,7 +184,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/finalize"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 67, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 67, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -197,7 +197,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 76, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 76, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -207,7 +207,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = CartSubcard("shipping-address-select", "Shipping Information", ShippingAddressSelect()).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = CartSubcard("shipping-address-select", "Shipping Information", ShippingAddressSelect(shippingPrefill)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -218,7 +218,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/payment-methods"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 105, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 105, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -258,7 +258,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/summary?data=summary_total"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 131, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 131, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -289,7 +289,7 @@ func CartPageBody(summaryContent templ.Component, showCPointsBanner bool) templ.
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templ.URL(utils.URL("/static/js/cart.js?v=" + fmt.Sprintf("%d", time.Now().Unix()))))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 166, Col: 123}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 166, Col: 123}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -336,7 +336,7 @@ func CartSummaryRow(left string, right string, class ...string) templ.Component 
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var12).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -349,7 +349,7 @@ func CartSummaryRow(left string, right string, class ...string) templ.Component 
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(left)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 173, Col: 12}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 173, Col: 12}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -362,7 +362,7 @@ func CartSummaryRow(left string, right string, class ...string) templ.Component 
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(right)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 174, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 174, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -409,7 +409,7 @@ func CartSummaryRowWithID(id string, left string, right string, class ...string)
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(id)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 179, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 179, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -422,7 +422,7 @@ func CartSummaryRowWithID(id string, left string, right string, class ...string)
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var17).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -435,7 +435,7 @@ func CartSummaryRowWithID(id string, left string, right string, class ...string)
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(left)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 180, Col: 12}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 180, Col: 12}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -448,7 +448,7 @@ func CartSummaryRowWithID(id string, left string, right string, class ...string)
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(right)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 181, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 181, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -674,7 +674,7 @@ func btnQtyDecrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs("btn-minus-" + cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 222, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 222, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -697,7 +697,7 @@ func btnQtyDecrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines/" + cl.ID + "?dec=1"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 228, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 228, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -710,7 +710,7 @@ func btnQtyDecrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("[name=qty-%s]", cl.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 229, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 229, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
@@ -752,7 +752,7 @@ func btnQtyIncrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs("btn-plus-" + cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 270, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 270, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
@@ -775,7 +775,7 @@ func btnQtyIncrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines/" + cl.ID + "?inc=1"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 276, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 276, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -788,7 +788,7 @@ func btnQtyIncrease(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("[name=qty-%s]", cl.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 277, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 277, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -830,7 +830,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var35 string
 		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs("cart-checkout-line-item-" + cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 317, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 317, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
@@ -843,7 +843,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 326, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 326, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -866,7 +866,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines/" + cl.ID + "/toggle"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 328, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 328, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
@@ -879,7 +879,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs("product image of " + cl.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 334, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 334, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
@@ -892,7 +892,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(cl.CDNURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 335, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 335, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -905,7 +905,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(cl.Name + " thumbnail")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 336, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 336, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -918,7 +918,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var41 string
 		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(cl.ProductID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 337, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 337, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 		if templ_7745c5c3_Err != nil {
@@ -939,7 +939,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(cl.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 343, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 343, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
@@ -952,7 +952,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(cl.BrandName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 344, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 344, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
@@ -965,7 +965,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(cl.WeightDisplay)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 345, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 345, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -983,7 +983,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(cl.Price.Display())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 349, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 349, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -996,7 +996,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(cl.OrigPrice.Display())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 352, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 352, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -1014,7 +1014,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 			var templ_7745c5c3_Var47 string
 			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(cl.OrigPrice.Display())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 356, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 356, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
@@ -1040,7 +1040,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var48 string
 		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs("qty-" + cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 363, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 363, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
@@ -1053,7 +1053,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var49 string
 		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(cl.Quantity)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 366, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 366, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 		if templ_7745c5c3_Err != nil {
@@ -1074,7 +1074,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var50 string
 		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(cl.Total.Display())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 371, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 371, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 		if templ_7745c5c3_Err != nil {
@@ -1087,7 +1087,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/carts/lines/" + cl.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 379, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 379, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
@@ -1100,7 +1100,7 @@ func CartCheckoutLineItem(cl models.CheckoutLine) templ.Component {
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs("#cart-checkout-line-item-" + cl.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 380, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 380, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -1150,7 +1150,7 @@ func CartSubcard(id string, label string, others ...templ.Component) templ.Compo
 		var templ_7745c5c3_Var54 string
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 396, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 396, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
@@ -1163,7 +1163,7 @@ func CartSubcard(id string, label string, others ...templ.Component) templ.Compo
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(id)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cmd/web/components/cart/index.templ`, Line: 398, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/index.templ`, Line: 398, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {

--- a/cmd/web/components/cart/shipping.templ
+++ b/cmd/web/components/cart/shipping.templ
@@ -3,6 +3,7 @@ package cart
 import "cchoice/internal/utils"
 import "cchoice/cmd/web/components/svg"
 import "cchoice/internal/constants"
+import "cchoice/cmd/web/models"
 
 templ MapOption(value string, name string) {
 	<option value={ value }>{ name }</option>
@@ -177,7 +178,7 @@ templ divInputWarning() {
 	</div>
 }
 
-templ infieldLabelInput(t string, name string, label string, pattern ...string) {
+templ infieldLabelInput(t string, name string, label string, value string, pattern ...string) {
 	<div class="relative">
 		<input
 			type={ t }
@@ -185,6 +186,7 @@ templ infieldLabelInput(t string, name string, label string, pattern ...string) 
 			class="border rounded-lg p-3 pt-6 w-full peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 			placeholder=" "
 			required
+			value={ value }
 			onblur="this.value = this.value.trim()"
 			if len(pattern) > 0 {
 				pattern={ pattern[0] }
@@ -226,7 +228,7 @@ templ infieldLabelSelect(id string, name string, label string, required bool, di
 	</div>
 }
 
-templ ShippingAddressSelect() {
+templ ShippingAddressSelect(prefill models.CartShippingPrefill) {
 	<div id="delivery-fee-loading-template" class="hidden">
 		<h1>Delivery Fee</h1>
 		<h1 class="text-right flex items-center gap-1">
@@ -284,21 +286,25 @@ templ ShippingAddressSelect() {
 			end
 
 			on load
-				-- Restore shipping form values from sessionStorage on page load
-				call restoreShippingFormState()
+				if sessionStorage.getItem('shippingFormState')
+					call restoreShippingFormState()
+				else
+					call restoreCustomerShippingPrefill()
+				end
 			end
 		"
 	>
-		@infieldLabelInput("email", "email", "E-Mail")
-		@infieldLabelInput("fullname", "fullname", "Full Name")
-		@infieldLabelInput("tel", "mobile_no", "Mobile Number (+63)", "^\\+63[0-9]{10}$")
-		@infieldLabelInput("text", "address_line1", "Address Line 1")
+		@infieldLabelInput("email", "email", "E-Mail", prefill.Email)
+		@infieldLabelInput("fullname", "fullname", "Full Name", prefill.FullName)
+		@infieldLabelInput("tel", "mobile_no", "Mobile Number (+63)", prefill.MobileNo, "^\\+63[0-9]{10}$")
+		@infieldLabelInput("text", "address_line1", "Address Line 1", prefill.AddressLine1)
 		<div class="relative">
 			<input
 				type="text"
 				name="address_line2"
 				class="border rounded-lg p-3 pt-6 w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 				placeholder=" "
+				value={ prefill.AddressLine2 }
 				onblur="this.value = this.value.trim()"
 			/>
 			<label
@@ -315,6 +321,7 @@ templ ShippingAddressSelect() {
 					class="border rounded-lg px-3 py-2 pt-6 w-full h-14 peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
 					placeholder=" "
 					required
+					value={ prefill.Postal }
 					pattern={ constants.PatternPostalCode }
 					onblur="this.value = this.value.trim()"
 				/>
@@ -353,7 +360,21 @@ templ ShippingAddressSelect() {
 		@CitySelect()
 		@BarangaySelect()
 	</div>
+	@templ.JSONScript("customer-shipping-prefill", prefill)
 	<script type="text/javascript">
+		const customerShippingPrefill = (() => {
+			const el = document.getElementById('customer-shipping-prefill');
+			if (!el) {
+				return {};
+			}
+
+			try {
+				return JSON.parse(el.textContent);
+			} catch (_) {
+				return {};
+			}
+		})();
+
 		function saveShippingFormState() {
 			const form = document.getElementById('shipping-form');
 			const formData = {
@@ -370,90 +391,105 @@ templ ShippingAddressSelect() {
 				cityDisabled: document.getElementById('city')?.disabled || false,
 				barangayDisabled: document.getElementById('barangay')?.disabled || false
 			};
-			console.log('Saving shipping form state:', formData);
 			sessionStorage.setItem('shippingFormState', JSON.stringify(formData));
+		}
+
+		function restoreCustomerShippingPrefill() {
+			if (!customerShippingPrefill || !customerShippingPrefill.Email) {
+				return;
+			}
+
+			applyShippingFormData({
+				email: customerShippingPrefill.Email || '',
+				fullname: customerShippingPrefill.FullName || '',
+				mobile_no: customerShippingPrefill.MobileNo || '',
+				address_line1: customerShippingPrefill.AddressLine1 || '',
+				address_line2: customerShippingPrefill.AddressLine2 || '',
+				postal: customerShippingPrefill.Postal || '',
+				province: customerShippingPrefill.Province || '',
+				city: customerShippingPrefill.City || '',
+				barangay: customerShippingPrefill.Barangay || '',
+				provinceText: customerShippingPrefill.Province || '',
+				cityDisabled: false,
+				barangayDisabled: false
+			});
 		}
 
 		function restoreShippingFormState() {
 			const saved = sessionStorage.getItem('shippingFormState');
-			console.log('Restoring shipping form state:', saved);
-			if (!saved)
-				return
+			if (!saved) {
+				return;
+			}
 
 			try {
-				const formData = JSON.parse(saved);
-				const form = document.getElementById('shipping-form');
-				const provinceSelect = document.getElementById('province');
-				const citySelect = document.getElementById('city');
-				const barangaySelect = document.getElementById('barangay');
-				console.log('Restoring shipping form state:', formData);
-
-				if (formData.email) {
-					const emailInput = form.querySelector('[name="email"]');
-					if (emailInput) emailInput.value = formData.email;
-				}
-				if (formData.fullname) {
-					const fullnameInput = form.querySelector('[name="fullname"]');
-					if (fullnameInput) fullnameInput.value = formData.fullname;
-				}
-				if (formData.mobile_no) {
-					const mobileInput = form.querySelector('[name="mobile_no"]');
-					if (mobileInput) mobileInput.value = formData.mobile_no;
-				}
-				if (formData.address_line1) {
-					const address1Input = form.querySelector('[name="address_line1"]');
-					if (address1Input) address1Input.value = formData.address_line1;
-				}
-				if (formData.address_line2) {
-					const address2Input = form.querySelector('[name="address_line2"]');
-					if (address2Input) address2Input.value = formData.address_line2;
-				}
-				if (formData.postal) {
-					const postalInput = form.querySelector('[name="postal"]');
-					if (postalInput) postalInput.value = formData.postal;
-				}
-
-				// Wait for province options to load
-				if (provinceSelect && formData.province) {
-					const checkAndRestore = () => {
-						if (provinceSelect.options.length > 1) {
-							provinceSelect.value = formData.province;
-
-							// Check if NCR
-							if (formData.provinceText && formData.provinceText.includes('National Capital Region')) {
-								// Restore NCR state
-								citySelect.innerHTML = '<option value="' + formData.city + '" selected>' + formData.city + '</option>';
-								citySelect.disabled = formData.cityDisabled;
-								barangaySelect.innerHTML = '<option value="' + formData.barangay + '" selected>' + formData.barangay + '</option>';
-								barangaySelect.disabled = formData.barangayDisabled;
-							} else {
-								// For other provinces, trigger the change to load cities
-								provinceSelect.dispatchEvent(new Event('change', { bubbles: true }));
-
-								// Wait for cities to load, then restore
-								setTimeout(() => {
-									if (citySelect && formData.city) {
-										citySelect.value = formData.city;
-										citySelect.dispatchEvent(new Event('change', { bubbles: true }));
-
-										// Wait for barangays to load
-										setTimeout(() => {
-											if (barangaySelect && formData.barangay) {
-												barangaySelect.value = formData.barangay;
-											}
-										}, 300);
-									}
-								}, 300);
-							}
-						} else {
-							// Options not loaded yet, wait a bit
-							setTimeout(checkAndRestore, 100);
-						}
-					};
-					checkAndRestore();
-				}
+				applyShippingFormData(JSON.parse(saved));
 			} catch (e) {
 				console.error('Failed to restore shipping form state:', e);
+			}
+		}
+
+		function applyShippingFormData(formData) {
+			const form = document.getElementById('shipping-form');
+			const provinceSelect = document.getElementById('province');
+			const citySelect = document.getElementById('city');
+			const barangaySelect = document.getElementById('barangay');
+
+			if (formData.email) {
+				const emailInput = form.querySelector('[name="email"]');
+				if (emailInput) emailInput.value = formData.email;
+			}
+			if (formData.fullname) {
+				const fullnameInput = form.querySelector('[name="fullname"]');
+				if (fullnameInput) fullnameInput.value = formData.fullname;
+			}
+			if (formData.mobile_no) {
+				const mobileInput = form.querySelector('[name="mobile_no"]');
+				if (mobileInput) mobileInput.value = formData.mobile_no;
+			}
+			if (formData.address_line1) {
+				const address1Input = form.querySelector('[name="address_line1"]');
+				if (address1Input) address1Input.value = formData.address_line1;
+			}
+			if (formData.address_line2) {
+				const address2Input = form.querySelector('[name="address_line2"]');
+				if (address2Input) address2Input.value = formData.address_line2;
+			}
+			if (formData.postal) {
+				const postalInput = form.querySelector('[name="postal"]');
+				if (postalInput) postalInput.value = formData.postal;
+			}
+
+			if (provinceSelect && formData.province) {
+				const checkAndRestore = () => {
+					if (provinceSelect.options.length > 1) {
+						provinceSelect.value = formData.province;
+
+						if (formData.provinceText && formData.provinceText.includes('National Capital Region')) {
+							citySelect.innerHTML = '<option value="' + formData.city + '" selected>' + formData.city + '</option>';
+							citySelect.disabled = formData.cityDisabled;
+							barangaySelect.innerHTML = '<option value="' + formData.barangay + '" selected>' + formData.barangay + '</option>';
+							barangaySelect.disabled = formData.barangayDisabled;
+						} else {
+							provinceSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+							setTimeout(() => {
+								if (citySelect && formData.city) {
+									citySelect.value = formData.city;
+									citySelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+									setTimeout(() => {
+										if (barangaySelect && formData.barangay) {
+											barangaySelect.value = formData.barangay;
+										}
+									}, 300);
+								}
+							}, 300);
+						}
+					} else {
+						setTimeout(checkAndRestore, 100);
+					}
+				};
+				checkAndRestore();
 			}
 		}
 	</script>

--- a/cmd/web/components/cart/shipping_templ.go
+++ b/cmd/web/components/cart/shipping_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import "cchoice/internal/utils"
 import "cchoice/cmd/web/components/svg"
 import "cchoice/internal/constants"
+import "cchoice/cmd/web/models"
 
 func MapOption(value string, name string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -40,7 +41,7 @@ func MapOption(value string, name string) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 8, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 9, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -53,7 +54,7 @@ func MapOption(value string, name string) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 8, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 9, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -95,7 +96,7 @@ func ProvinceSelect() templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/address?data=provinces"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 18, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 19, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -108,7 +109,7 @@ func ProvinceSelect() templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/quotation"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 21, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 22, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -150,7 +151,7 @@ func CitySelect() templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/address?data=cities"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 79, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 80, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -192,7 +193,7 @@ func BarangaySelect() templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/address?data=barangays"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 115, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 116, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -234,7 +235,7 @@ func input(t string, name string, placeholder string, pattern ...string) templ.C
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 137, Col: 10}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 138, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -247,7 +248,7 @@ func input(t string, name string, placeholder string, pattern ...string) templ.C
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 138, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 139, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -260,7 +261,7 @@ func input(t string, name string, placeholder string, pattern ...string) templ.C
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 140, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 141, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -278,7 +279,7 @@ func input(t string, name string, placeholder string, pattern ...string) templ.C
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(pattern[0])
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 144, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 145, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -330,7 +331,7 @@ func inputWithClass(t string, name string, placeholder string, class string, pat
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 151, Col: 10}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 152, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -343,7 +344,7 @@ func inputWithClass(t string, name string, placeholder string, class string, pat
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 152, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 153, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -369,7 +370,7 @@ func inputWithClass(t string, name string, placeholder string, class string, pat
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 154, Col: 27}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 155, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -387,7 +388,7 @@ func inputWithClass(t string, name string, placeholder string, class string, pat
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(pattern[0])
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 158, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 159, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -434,7 +435,7 @@ func warning(text string) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(text)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 170, Col: 8}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 171, Col: 8}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -485,7 +486,7 @@ func divInputWarning() templ.Component {
 	})
 }
 
-func infieldLabelInput(t string, name string, label string, pattern ...string) templ.Component {
+func infieldLabelInput(t string, name string, label string, value string, pattern ...string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -513,7 +514,7 @@ func infieldLabelInput(t string, name string, label string, pattern ...string) t
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 183, Col: 11}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 184, Col: 11}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -526,62 +527,75 @@ func infieldLabelInput(t string, name string, label string, pattern ...string) t
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 184, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 185, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"border rounded-lg p-3 pt-6 w-full peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" required onblur=\"this.value = this.value.trim()\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"border rounded-lg p-3 pt-6 w-full peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" required value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var29 string
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 189, Col: 16}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" onblur=\"this.value = this.value.trim()\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(pattern) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " pattern=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " pattern=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(pattern[0])
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(pattern[0])
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 190, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 192, Col: 24}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var30 string
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(label)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 196, Col: 10}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</label> <small class=\"text-red-500 text-xs block invisible h-0 mt-1 peer-invalid:visible peer-invalid:h-auto\">Please enter a valid ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 204, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 198, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</small></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</label> <small class=\"text-red-500 text-xs block invisible h-0 mt-1 peer-invalid:visible peer-invalid:h-auto\">Please enter a valid ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 206, Col: 31}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</small></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -605,82 +619,82 @@ func infieldLabelSelect(id string, name string, label string, required bool, dis
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var32 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var32 == nil {
-			templ_7745c5c3_Var32 = templ.NopComponent
+		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var33 == nil {
+			templ_7745c5c3_Var33 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div class=\"relative\"><select id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var33 string
-		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(id)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 212, Col: 10}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<div class=\"relative\"><select id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(id)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 213, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 214, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" class=\"border rounded-lg p-3 pt-6 w-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" required=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var35 string
-		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(required)
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 215, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 215, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if disabled {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " disabled")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "><option value=\"\"></option>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var32.Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</select> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" class=\"border rounded-lg p-3 pt-6 w-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" required=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var36 string
-		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(required)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 224, Col: 10}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 217, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</label></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if disabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " disabled")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "><option value=\"\"></option>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ_7745c5c3_Var33.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</select> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var37 string
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 226, Col: 10}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</label></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -688,7 +702,7 @@ func infieldLabelSelect(id string, name string, label string, required bool, dis
 	})
 }
 
-func ShippingAddressSelect() templ.Component {
+func ShippingAddressSelect(prefill models.CartShippingPrefill) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -704,12 +718,12 @@ func ShippingAddressSelect() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var37 == nil {
-			templ_7745c5c3_Var37 = templ.NopComponent
+		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var38 == nil {
+			templ_7745c5c3_Var38 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div id=\"delivery-fee-loading-template\" class=\"hidden\"><h1>Delivery Fee</h1><h1 class=\"text-right flex items-center gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div id=\"delivery-fee-loading-template\" class=\"hidden\"><h1>Delivery Fee</h1><h1 class=\"text-right flex items-center gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -717,7 +731,7 @@ func ShippingAddressSelect() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<span>Calculating...</span></h1></div><div id=\"delivery-eta-loading-template\" class=\"hidden\"><h1>Estimated Delivery Time</h1><h1 class=\"text-right flex items-center gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<span>Calculating...</span></h1></div><div id=\"delivery-eta-loading-template\" class=\"hidden\"><h1>Estimated Delivery Time</h1><h1 class=\"text-right flex items-center gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -725,53 +739,79 @@ func ShippingAddressSelect() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<span>Calculating...</span></h1></div><div class=\"flex flex-col gap-2 w-full max-w-lg\" id=\"shipping-form\" hx-post=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var38 string
-		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/quotation"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 247, Col: 44}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" hx-trigger=\"post\" hx-swap=\"none\" _=\"\n\t\t\ton change from .required-field\n\t\t\t\tif #city.value !== '' and #province.value !== '' and #barangay.value !== ''\n\t\t\t\t\tlog 'Province, city, and barangay completed, calculating shipping...'\n\t\t\t\t\ttrigger post on #shipping-form\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton change from <input/> or change from <select/>\n\t\t\t\tcall saveShippingFormState()\n\t\t\tend\n\n\t\t\ton htmx:beforeRequest\n\t\t\t\tif event.detail.requestConfig.verb is 'post' and event.detail.requestConfig.path contains '/shipping/quotation'\n\t\t\t\t\tput #delivery-fee-row into deliveryRow\n\t\t\t\t\tput #delivery-fee-loading-template into feeLoadingTemplate\n\t\t\t\t\tif deliveryRow is not null and feeLoadingTemplate is not null\n\t\t\t\t\t\tset deliveryRow.innerHTML to feeLoadingTemplate.innerHTML\n\t\t\t\t\tend\n\n\t\t\t\t\tput #delivery-eta-row into etaRow\n\t\t\t\t\tput #delivery-eta-loading-template into etaLoadingTemplate\n\t\t\t\t\tif etaRow is not null and etaLoadingTemplate is not null\n\t\t\t\t\t\tset etaRow.innerHTML to etaLoadingTemplate.innerHTML\n\t\t\t\t\tend\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton htmx:afterRequest\n\t\t\t\tif event.detail.requestConfig.verb is 'post' and event.detail.requestConfig.path contains '/shipping/quotation'\n\t\t\t\t\ttrigger get on #cart-summary-content\n\t\t\t\t\t-- Save shipping form values to sessionStorage for page refresh\n\t\t\t\t\tcall saveShippingFormState()\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton load\n\t\t\t\t-- Restore shipping form values from sessionStorage on page load\n\t\t\t\tcall restoreShippingFormState()\n\t\t\tend\n\t\t\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = infieldLabelInput("email", "email", "E-Mail").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = infieldLabelInput("fullname", "fullname", "Full Name").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = infieldLabelInput("tel", "mobile_no", "Mobile Number (+63)", "^\\+63[0-9]{10}$").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = infieldLabelInput("text", "address_line1", "Address Line 1").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"relative\"><input type=\"text\" name=\"address_line2\" class=\"border rounded-lg p-3 pt-6 w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" onblur=\"this.value = this.value.trim()\"> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Address Line 2 (Optional)</label></div><div class=\"flex flex-row gap-1\"><div class=\"relative w-1/2\"><input type=\"text\" name=\"postal\" class=\"border rounded-lg px-3 py-2 pt-6 w-full h-14 peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" required pattern=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<span>Calculating...</span></h1></div><div class=\"flex flex-col gap-2 w-full max-w-lg\" id=\"shipping-form\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
-		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(constants.PatternPostalCode)
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(utils.URL("/shipping/quotation"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 318, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 249, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" onblur=\"this.value = this.value.trim()\"> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Postal Code</label> <small class=\"text-red-500 text-xs block invisible h-0 mt-1 peer-invalid:visible peer-invalid:h-auto\">Please enter a valid postal code (4 digits only)</small></div><div class=\"relative w-1/2\"><select id=\"country\" name=\"country\" class=\"border rounded-lg px-3 py-2 pt-6 w-full h-14 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" required disabled><option value=\"PH\" selected>Philippines</option></select> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Country</label></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\" hx-trigger=\"post\" hx-swap=\"none\" _=\"\n\t\t\ton change from .required-field\n\t\t\t\tif #city.value !== '' and #province.value !== '' and #barangay.value !== ''\n\t\t\t\t\tlog 'Province, city, and barangay completed, calculating shipping...'\n\t\t\t\t\ttrigger post on #shipping-form\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton change from <input/> or change from <select/>\n\t\t\t\tcall saveShippingFormState()\n\t\t\tend\n\n\t\t\ton htmx:beforeRequest\n\t\t\t\tif event.detail.requestConfig.verb is 'post' and event.detail.requestConfig.path contains '/shipping/quotation'\n\t\t\t\t\tput #delivery-fee-row into deliveryRow\n\t\t\t\t\tput #delivery-fee-loading-template into feeLoadingTemplate\n\t\t\t\t\tif deliveryRow is not null and feeLoadingTemplate is not null\n\t\t\t\t\t\tset deliveryRow.innerHTML to feeLoadingTemplate.innerHTML\n\t\t\t\t\tend\n\n\t\t\t\t\tput #delivery-eta-row into etaRow\n\t\t\t\t\tput #delivery-eta-loading-template into etaLoadingTemplate\n\t\t\t\t\tif etaRow is not null and etaLoadingTemplate is not null\n\t\t\t\t\t\tset etaRow.innerHTML to etaLoadingTemplate.innerHTML\n\t\t\t\t\tend\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton htmx:afterRequest\n\t\t\t\tif event.detail.requestConfig.verb is 'post' and event.detail.requestConfig.path contains '/shipping/quotation'\n\t\t\t\t\ttrigger get on #cart-summary-content\n\t\t\t\t\t-- Save shipping form values to sessionStorage for page refresh\n\t\t\t\t\tcall saveShippingFormState()\n\t\t\t\tend\n\t\t\tend\n\n\t\t\ton load\n\t\t\t\tif sessionStorage.getItem('shippingFormState')\n\t\t\t\t\tcall restoreShippingFormState()\n\t\t\t\telse\n\t\t\t\t\tcall restoreCustomerShippingPrefill()\n\t\t\t\tend\n\t\t\tend\n\t\t\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = infieldLabelInput("email", "email", "E-Mail", prefill.Email).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = infieldLabelInput("fullname", "fullname", "Full Name", prefill.FullName).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = infieldLabelInput("tel", "mobile_no", "Mobile Number (+63)", prefill.MobileNo, "^\\+63[0-9]{10}$").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = infieldLabelInput("text", "address_line1", "Address Line 1", prefill.AddressLine1).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"relative\"><input type=\"text\" name=\"address_line2\" class=\"border rounded-lg p-3 pt-6 w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var40 string
+		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(prefill.AddressLine2)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 307, Col: 32}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" onblur=\"this.value = this.value.trim()\"> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Address Line 2 (Optional)</label></div><div class=\"flex flex-row gap-1\"><div class=\"relative w-1/2\"><input type=\"text\" name=\"postal\" class=\"border rounded-lg px-3 py-2 pt-6 w-full h-14 peer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" placeholder=\" \" required value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var41 string
+		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(prefill.Postal)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 324, Col: 27}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" pattern=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var42 string
+		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(constants.PatternPostalCode)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `cart/shipping.templ`, Line: 325, Col: 42}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" onblur=\"this.value = this.value.trim()\"> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Postal Code</label> <small class=\"text-red-500 text-xs block invisible h-0 mt-1 peer-invalid:visible peer-invalid:h-auto\">Please enter a valid postal code (4 digits only)</small></div><div class=\"relative w-1/2\"><select id=\"country\" name=\"country\" class=\"border rounded-lg px-3 py-2 pt-6 w-full h-14 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent\" required disabled><option value=\"PH\" selected>Philippines</option></select> <label class=\"absolute left-3 top-1 text-xs text-gray-500 font-medium pointer-events-none\">Country</label></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -787,7 +827,15 @@ func ShippingAddressSelect() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div><script type=\"text/javascript\">\n\t\tfunction saveShippingFormState() {\n\t\t\tconst form = document.getElementById('shipping-form');\n\t\t\tconst formData = {\n\t\t\t\temail: form.querySelector('[name=\"email\"]')?.value || '',\n\t\t\t\tfullname: form.querySelector('[name=\"fullname\"]')?.value || '',\n\t\t\t\tmobile_no: form.querySelector('[name=\"mobile_no\"]')?.value || '',\n\t\t\t\taddress_line1: form.querySelector('[name=\"address_line1\"]')?.value || '',\n\t\t\t\taddress_line2: form.querySelector('[name=\"address_line2\"]')?.value || '',\n\t\t\t\tpostal: form.querySelector('[name=\"postal\"]')?.value || '',\n\t\t\t\tprovince: document.getElementById('province')?.value || '',\n\t\t\t\tcity: document.getElementById('city')?.value || '',\n\t\t\t\tbarangay: document.getElementById('barangay')?.value || '',\n\t\t\t\tprovinceText: document.getElementById('province')?.selectedOptions[0]?.text || '',\n\t\t\t\tcityDisabled: document.getElementById('city')?.disabled || false,\n\t\t\t\tbarangayDisabled: document.getElementById('barangay')?.disabled || false\n\t\t\t};\n\t\t\tconsole.log('Saving shipping form state:', formData);\n\t\t\tsessionStorage.setItem('shippingFormState', JSON.stringify(formData));\n\t\t}\n\n\t\tfunction restoreShippingFormState() {\n\t\t\tconst saved = sessionStorage.getItem('shippingFormState');\n\t\t\tconsole.log('Restoring shipping form state:', saved);\n\t\t\tif (!saved)\n\t\t\t\treturn\n\n\t\t\ttry {\n\t\t\t\tconst formData = JSON.parse(saved);\n\t\t\t\tconst form = document.getElementById('shipping-form');\n\t\t\t\tconst provinceSelect = document.getElementById('province');\n\t\t\t\tconst citySelect = document.getElementById('city');\n\t\t\t\tconst barangaySelect = document.getElementById('barangay');\n\t\t\t\tconsole.log('Restoring shipping form state:', formData);\n\n\t\t\t\tif (formData.email) {\n\t\t\t\t\tconst emailInput = form.querySelector('[name=\"email\"]');\n\t\t\t\t\tif (emailInput) emailInput.value = formData.email;\n\t\t\t\t}\n\t\t\t\tif (formData.fullname) {\n\t\t\t\t\tconst fullnameInput = form.querySelector('[name=\"fullname\"]');\n\t\t\t\t\tif (fullnameInput) fullnameInput.value = formData.fullname;\n\t\t\t\t}\n\t\t\t\tif (formData.mobile_no) {\n\t\t\t\t\tconst mobileInput = form.querySelector('[name=\"mobile_no\"]');\n\t\t\t\t\tif (mobileInput) mobileInput.value = formData.mobile_no;\n\t\t\t\t}\n\t\t\t\tif (formData.address_line1) {\n\t\t\t\t\tconst address1Input = form.querySelector('[name=\"address_line1\"]');\n\t\t\t\t\tif (address1Input) address1Input.value = formData.address_line1;\n\t\t\t\t}\n\t\t\t\tif (formData.address_line2) {\n\t\t\t\t\tconst address2Input = form.querySelector('[name=\"address_line2\"]');\n\t\t\t\t\tif (address2Input) address2Input.value = formData.address_line2;\n\t\t\t\t}\n\t\t\t\tif (formData.postal) {\n\t\t\t\t\tconst postalInput = form.querySelector('[name=\"postal\"]');\n\t\t\t\t\tif (postalInput) postalInput.value = formData.postal;\n\t\t\t\t}\n\n\t\t\t\t// Wait for province options to load\n\t\t\t\tif (provinceSelect && formData.province) {\n\t\t\t\t\tconst checkAndRestore = () => {\n\t\t\t\t\t\tif (provinceSelect.options.length > 1) {\n\t\t\t\t\t\t\tprovinceSelect.value = formData.province;\n\n\t\t\t\t\t\t\t// Check if NCR\n\t\t\t\t\t\t\tif (formData.provinceText && formData.provinceText.includes('National Capital Region')) {\n\t\t\t\t\t\t\t\t// Restore NCR state\n\t\t\t\t\t\t\t\tcitySelect.innerHTML = '<option value=\"' + formData.city + '\" selected>' + formData.city + '</option>';\n\t\t\t\t\t\t\t\tcitySelect.disabled = formData.cityDisabled;\n\t\t\t\t\t\t\t\tbarangaySelect.innerHTML = '<option value=\"' + formData.barangay + '\" selected>' + formData.barangay + '</option>';\n\t\t\t\t\t\t\t\tbarangaySelect.disabled = formData.barangayDisabled;\n\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\t// For other provinces, trigger the change to load cities\n\t\t\t\t\t\t\t\tprovinceSelect.dispatchEvent(new Event('change', { bubbles: true }));\n\n\t\t\t\t\t\t\t\t// Wait for cities to load, then restore\n\t\t\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\t\t\tif (citySelect && formData.city) {\n\t\t\t\t\t\t\t\t\t\tcitySelect.value = formData.city;\n\t\t\t\t\t\t\t\t\t\tcitySelect.dispatchEvent(new Event('change', { bubbles: true }));\n\n\t\t\t\t\t\t\t\t\t\t// Wait for barangays to load\n\t\t\t\t\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\t\t\t\t\tif (barangaySelect && formData.barangay) {\n\t\t\t\t\t\t\t\t\t\t\t\tbarangaySelect.value = formData.barangay;\n\t\t\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t\t\t}, 300);\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t}, 300);\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t// Options not loaded yet, wait a bit\n\t\t\t\t\t\t\tsetTimeout(checkAndRestore, 100);\n\t\t\t\t\t\t}\n\t\t\t\t\t};\n\t\t\t\t\tcheckAndRestore();\n\t\t\t\t}\n\t\t\t} catch (e) {\n\t\t\t\tconsole.error('Failed to restore shipping form state:', e);\n\t\t\t}\n\t\t}\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.JSONScript("customer-shipping-prefill", prefill).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<script type=\"text/javascript\">\n\t\tconst customerShippingPrefill = (() => {\n\t\t\tconst el = document.getElementById('customer-shipping-prefill');\n\t\t\tif (!el) {\n\t\t\t\treturn {};\n\t\t\t}\n\n\t\t\ttry {\n\t\t\t\treturn JSON.parse(el.textContent);\n\t\t\t} catch (_) {\n\t\t\t\treturn {};\n\t\t\t}\n\t\t})();\n\n\t\tfunction saveShippingFormState() {\n\t\t\tconst form = document.getElementById('shipping-form');\n\t\t\tconst formData = {\n\t\t\t\temail: form.querySelector('[name=\"email\"]')?.value || '',\n\t\t\t\tfullname: form.querySelector('[name=\"fullname\"]')?.value || '',\n\t\t\t\tmobile_no: form.querySelector('[name=\"mobile_no\"]')?.value || '',\n\t\t\t\taddress_line1: form.querySelector('[name=\"address_line1\"]')?.value || '',\n\t\t\t\taddress_line2: form.querySelector('[name=\"address_line2\"]')?.value || '',\n\t\t\t\tpostal: form.querySelector('[name=\"postal\"]')?.value || '',\n\t\t\t\tprovince: document.getElementById('province')?.value || '',\n\t\t\t\tcity: document.getElementById('city')?.value || '',\n\t\t\t\tbarangay: document.getElementById('barangay')?.value || '',\n\t\t\t\tprovinceText: document.getElementById('province')?.selectedOptions[0]?.text || '',\n\t\t\t\tcityDisabled: document.getElementById('city')?.disabled || false,\n\t\t\t\tbarangayDisabled: document.getElementById('barangay')?.disabled || false\n\t\t\t};\n\t\t\tsessionStorage.setItem('shippingFormState', JSON.stringify(formData));\n\t\t}\n\n\t\tfunction restoreCustomerShippingPrefill() {\n\t\t\tif (!customerShippingPrefill || !customerShippingPrefill.Email) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\tapplyShippingFormData({\n\t\t\t\temail: customerShippingPrefill.Email || '',\n\t\t\t\tfullname: customerShippingPrefill.FullName || '',\n\t\t\t\tmobile_no: customerShippingPrefill.MobileNo || '',\n\t\t\t\taddress_line1: customerShippingPrefill.AddressLine1 || '',\n\t\t\t\taddress_line2: customerShippingPrefill.AddressLine2 || '',\n\t\t\t\tpostal: customerShippingPrefill.Postal || '',\n\t\t\t\tprovince: customerShippingPrefill.Province || '',\n\t\t\t\tcity: customerShippingPrefill.City || '',\n\t\t\t\tbarangay: customerShippingPrefill.Barangay || '',\n\t\t\t\tprovinceText: customerShippingPrefill.Province || '',\n\t\t\t\tcityDisabled: false,\n\t\t\t\tbarangayDisabled: false\n\t\t\t});\n\t\t}\n\n\t\tfunction restoreShippingFormState() {\n\t\t\tconst saved = sessionStorage.getItem('shippingFormState');\n\t\t\tif (!saved) {\n\t\t\t\treturn;\n\t\t\t}\n\n\t\t\ttry {\n\t\t\t\tapplyShippingFormData(JSON.parse(saved));\n\t\t\t} catch (e) {\n\t\t\t\tconsole.error('Failed to restore shipping form state:', e);\n\t\t\t}\n\t\t}\n\n\t\tfunction applyShippingFormData(formData) {\n\t\t\tconst form = document.getElementById('shipping-form');\n\t\t\tconst provinceSelect = document.getElementById('province');\n\t\t\tconst citySelect = document.getElementById('city');\n\t\t\tconst barangaySelect = document.getElementById('barangay');\n\n\t\t\tif (formData.email) {\n\t\t\t\tconst emailInput = form.querySelector('[name=\"email\"]');\n\t\t\t\tif (emailInput) emailInput.value = formData.email;\n\t\t\t}\n\t\t\tif (formData.fullname) {\n\t\t\t\tconst fullnameInput = form.querySelector('[name=\"fullname\"]');\n\t\t\t\tif (fullnameInput) fullnameInput.value = formData.fullname;\n\t\t\t}\n\t\t\tif (formData.mobile_no) {\n\t\t\t\tconst mobileInput = form.querySelector('[name=\"mobile_no\"]');\n\t\t\t\tif (mobileInput) mobileInput.value = formData.mobile_no;\n\t\t\t}\n\t\t\tif (formData.address_line1) {\n\t\t\t\tconst address1Input = form.querySelector('[name=\"address_line1\"]');\n\t\t\t\tif (address1Input) address1Input.value = formData.address_line1;\n\t\t\t}\n\t\t\tif (formData.address_line2) {\n\t\t\t\tconst address2Input = form.querySelector('[name=\"address_line2\"]');\n\t\t\t\tif (address2Input) address2Input.value = formData.address_line2;\n\t\t\t}\n\t\t\tif (formData.postal) {\n\t\t\t\tconst postalInput = form.querySelector('[name=\"postal\"]');\n\t\t\t\tif (postalInput) postalInput.value = formData.postal;\n\t\t\t}\n\n\t\t\tif (provinceSelect && formData.province) {\n\t\t\t\tconst checkAndRestore = () => {\n\t\t\t\t\tif (provinceSelect.options.length > 1) {\n\t\t\t\t\t\tprovinceSelect.value = formData.province;\n\n\t\t\t\t\t\tif (formData.provinceText && formData.provinceText.includes('National Capital Region')) {\n\t\t\t\t\t\t\tcitySelect.innerHTML = '<option value=\"' + formData.city + '\" selected>' + formData.city + '</option>';\n\t\t\t\t\t\t\tcitySelect.disabled = formData.cityDisabled;\n\t\t\t\t\t\t\tbarangaySelect.innerHTML = '<option value=\"' + formData.barangay + '\" selected>' + formData.barangay + '</option>';\n\t\t\t\t\t\t\tbarangaySelect.disabled = formData.barangayDisabled;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tprovinceSelect.dispatchEvent(new Event('change', { bubbles: true }));\n\n\t\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\t\tif (citySelect && formData.city) {\n\t\t\t\t\t\t\t\t\tcitySelect.value = formData.city;\n\t\t\t\t\t\t\t\t\tcitySelect.dispatchEvent(new Event('change', { bubbles: true }));\n\n\t\t\t\t\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\t\t\t\t\tif (barangaySelect && formData.barangay) {\n\t\t\t\t\t\t\t\t\t\t\tbarangaySelect.value = formData.barangay;\n\t\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t\t}, 300);\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}, 300);\n\t\t\t\t\t\t}\n\t\t\t\t\t} else {\n\t\t\t\t\t\tsetTimeout(checkAndRestore, 100);\n\t\t\t\t\t}\n\t\t\t\t};\n\t\t\t\tcheckAndRestore();\n\t\t\t}\n\t\t}\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/cmd/web/models/cart_shipping.go
+++ b/cmd/web/models/cart_shipping.go
@@ -1,0 +1,25 @@
+package models
+
+type CartShippingPrefill struct {
+	Email        string
+	FullName     string
+	MobileNo     string
+	AddressLine1 string
+	AddressLine2 string
+	Postal       string
+	Province     string
+	City         string
+	Barangay     string
+}
+
+func (p CartShippingPrefill) HasData() bool {
+	return p.Email != "" ||
+		p.FullName != "" ||
+		p.MobileNo != "" ||
+		p.AddressLine1 != "" ||
+		p.AddressLine2 != "" ||
+		p.Postal != "" ||
+		p.Province != "" ||
+		p.City != "" ||
+		p.Barangay != ""
+}

--- a/internal/database/queries/models.go
+++ b/internal/database/queries/models.go
@@ -275,6 +275,8 @@ type TblOrder struct {
 	UpdatedAt                time.Time
 	PaidAt                   sql.NullTime
 	ShippingEta              sql.NullString
+	CustomerID               sql.NullInt64
+	ShippingBarangay         string
 }
 
 type TblOrderLine struct {

--- a/internal/database/queries/order.sql.go
+++ b/internal/database/queries/order.sql.go
@@ -640,6 +640,7 @@ INSERT INTO tbl_orders(
 	checkout_payment_id,
 	order_number,
 	status,
+	customer_id,
 	customer_name,
 	customer_email,
 	customer_phone,
@@ -655,6 +656,7 @@ INSERT INTO tbl_orders(
 	billing_place_id,
 	shipping_address_line1,
 	shipping_address_line2,
+	shipping_barangay,
 	shipping_city,
 	shipping_state,
 	shipping_postal_code,
@@ -677,17 +679,17 @@ INSERT INTO tbl_orders(
 	created_at,
 	updated_at
 ) VALUES (
+	?, ?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
-	?, ?, ?, ?, ?,
-	?, ?, ?,
+	?, ?, ?, ?,
 	datetime('now'),
 	datetime('now')
-) RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta
+) RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay
 `
 
 type CreateOrderParams struct {
@@ -695,6 +697,7 @@ type CreateOrderParams struct {
 	CheckoutPaymentID        string
 	OrderNumber              string
 	Status                   string
+	CustomerID               sql.NullInt64
 	CustomerName             string
 	CustomerEmail            string
 	CustomerPhone            string
@@ -710,6 +713,7 @@ type CreateOrderParams struct {
 	BillingPlaceID           sql.NullString
 	ShippingAddressLine1     string
 	ShippingAddressLine2     string
+	ShippingBarangay         string
 	ShippingCity             string
 	ShippingState            string
 	ShippingPostalCode       string
@@ -737,6 +741,7 @@ func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (TblOr
 		arg.CheckoutPaymentID,
 		arg.OrderNumber,
 		arg.Status,
+		arg.CustomerID,
 		arg.CustomerName,
 		arg.CustomerEmail,
 		arg.CustomerPhone,
@@ -752,6 +757,7 @@ func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (TblOr
 		arg.BillingPlaceID,
 		arg.ShippingAddressLine1,
 		arg.ShippingAddressLine2,
+		arg.ShippingBarangay,
 		arg.ShippingCity,
 		arg.ShippingState,
 		arg.ShippingPostalCode,
@@ -816,6 +822,8 @@ func (q *Queries) CreateOrder(ctx context.Context, arg CreateOrderParams) (TblOr
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
@@ -887,8 +895,46 @@ func (q *Queries) CreateOrderLine(ctx context.Context, arg CreateOrderLineParams
 	return i, err
 }
 
+const getLatestOrderShippingByCustomerID = `-- name: GetLatestOrderShippingByCustomerID :one
+SELECT
+	shipping_address_line1,
+	shipping_address_line2,
+	shipping_barangay,
+	shipping_city,
+	shipping_state,
+	shipping_postal_code
+FROM tbl_orders
+WHERE
+	customer_id = ?
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+type GetLatestOrderShippingByCustomerIDRow struct {
+	ShippingAddressLine1 string
+	ShippingAddressLine2 string
+	ShippingBarangay     string
+	ShippingCity         string
+	ShippingState        string
+	ShippingPostalCode   string
+}
+
+func (q *Queries) GetLatestOrderShippingByCustomerID(ctx context.Context, customerID sql.NullInt64) (GetLatestOrderShippingByCustomerIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getLatestOrderShippingByCustomerID, customerID)
+	var i GetLatestOrderShippingByCustomerIDRow
+	err := row.Scan(
+		&i.ShippingAddressLine1,
+		&i.ShippingAddressLine2,
+		&i.ShippingBarangay,
+		&i.ShippingCity,
+		&i.ShippingState,
+		&i.ShippingPostalCode,
+	)
+	return i, err
+}
+
 const getOrderByCheckoutID = `-- name: GetOrderByCheckoutID :one
-SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta FROM tbl_orders
+SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay FROM tbl_orders
 WHERE checkout_id = ?
 LIMIT 1
 `
@@ -939,12 +985,14 @@ func (q *Queries) GetOrderByCheckoutID(ctx context.Context, checkoutID int64) (T
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
 
 const getOrderByCheckoutPaymentID = `-- name: GetOrderByCheckoutPaymentID :one
-SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta FROM tbl_orders
+SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay FROM tbl_orders
 WHERE checkout_payment_id = ?
 LIMIT 1
 `
@@ -995,12 +1043,14 @@ func (q *Queries) GetOrderByCheckoutPaymentID(ctx context.Context, checkoutPayme
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
 
 const getOrderByID = `-- name: GetOrderByID :one
-SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta FROM tbl_orders
+SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay FROM tbl_orders
 WHERE id = ?
 LIMIT 1
 `
@@ -1051,12 +1101,14 @@ func (q *Queries) GetOrderByID(ctx context.Context, id int64) (TblOrder, error) 
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
 
 const getOrderByOrderNumber = `-- name: GetOrderByOrderNumber :one
-SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta FROM tbl_orders
+SELECT id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay FROM tbl_orders
 WHERE order_number = ?
 LIMIT 1
 `
@@ -1107,6 +1159,8 @@ func (q *Queries) GetOrderByOrderNumber(ctx context.Context, orderNumber string)
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
@@ -1187,7 +1241,7 @@ SET status = ?,
 	paid_at = DATETIME('now'),
 	updated_at = DATETIME('now')
 WHERE id = ?
-RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta
+RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay
 `
 
 type UpdateOrderOnPaymentSuccessParams struct {
@@ -1241,6 +1295,8 @@ func (q *Queries) UpdateOrderOnPaymentSuccess(ctx context.Context, arg UpdateOrd
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
@@ -1253,7 +1309,7 @@ SET shipping_service = ?,
 	shipping_eta = ?,
 	updated_at = DATETIME('now')
 WHERE id = ?
-RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta
+RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay
 `
 
 type UpdateOrderShippingInfoParams struct {
@@ -1316,6 +1372,8 @@ func (q *Queries) UpdateOrderShippingInfo(ctx context.Context, arg UpdateOrderSh
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }
@@ -1325,7 +1383,7 @@ UPDATE tbl_orders
 SET status = ?,
 	updated_at = DATETIME('now')
 WHERE id = ?
-RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta
+RETURNING id, checkout_id, checkout_payment_id, order_number, status, customer_name, customer_email, customer_phone, billing_address_line1, billing_address_line2, billing_city, billing_state, billing_postal_code, billing_country, billing_latitude, billing_longitude, billing_formatted_address, billing_place_id, shipping_address_line1, shipping_address_line2, shipping_city, shipping_state, shipping_postal_code, shipping_country, shipping_latitude, shipping_longitude, shipping_formatted_address, shipping_place_id, subtotal_amount, shipping_amount, discount_amount, total_amount, currency, shipping_service, shipping_order_id, shipping_tracking_number, notes, remarks, created_at, updated_at, paid_at, shipping_eta, customer_id, shipping_barangay
 `
 
 type UpdateOrderStatusParams struct {
@@ -1379,6 +1437,8 @@ func (q *Queries) UpdateOrderStatus(ctx context.Context, arg UpdateOrderStatusPa
 		&i.UpdatedAt,
 		&i.PaidAt,
 		&i.ShippingEta,
+		&i.CustomerID,
+		&i.ShippingBarangay,
 	)
 	return i, err
 }

--- a/internal/database/sql/order.sql
+++ b/internal/database/sql/order.sql
@@ -4,6 +4,7 @@ INSERT INTO tbl_orders(
 	checkout_payment_id,
 	order_number,
 	status,
+	customer_id,
 	customer_name,
 	customer_email,
 	customer_phone,
@@ -19,6 +20,7 @@ INSERT INTO tbl_orders(
 	billing_place_id,
 	shipping_address_line1,
 	shipping_address_line2,
+	shipping_barangay,
 	shipping_city,
 	shipping_state,
 	shipping_postal_code,
@@ -41,17 +43,31 @@ INSERT INTO tbl_orders(
 	created_at,
 	updated_at
 ) VALUES (
+	?, ?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
 	?, ?, ?, ?, ?,
-	?, ?, ?, ?, ?,
-	?, ?, ?,
+	?, ?, ?, ?,
 	datetime('now'),
 	datetime('now')
 ) RETURNING *;
+
+-- name: GetLatestOrderShippingByCustomerID :one
+SELECT
+	shipping_address_line1,
+	shipping_address_line2,
+	shipping_barangay,
+	shipping_city,
+	shipping_state,
+	shipping_postal_code
+FROM tbl_orders
+WHERE
+	customer_id = ?
+ORDER BY created_at DESC
+LIMIT 1;
 
 -- name: GetOrderByID :one
 SELECT * FROM tbl_orders

--- a/internal/orders/orders.go
+++ b/internal/orders/orders.go
@@ -45,6 +45,7 @@ type CreateOrderParams struct {
 	Checkout                cart.CartCheckout
 	CheckoutLines           []queries.GetCheckoutLinesByCheckoutIDRow
 	CheckoutID              int64
+	CustomerID              sql.NullInt64
 }
 
 const (
@@ -195,7 +196,8 @@ func CreateOrderFromCheckout(
 		CheckoutPaymentID:        checkoutPayment.ID,
 		OrderNumber:              orderNumber,
 		Status:                   enums.ORDER_STATUS_PENDING.String(),
-		CustomerName:             params.Checkout.Email,
+		CustomerID:               params.CustomerID,
+		CustomerName:             params.Checkout.FullName,
 		CustomerEmail:            params.Checkout.Email,
 		CustomerPhone:            params.Checkout.MobileNo,
 		BillingAddressLine1:      params.Checkout.AddressLine1,
@@ -210,6 +212,7 @@ func CreateOrderFromCheckout(
 		BillingPlaceID:           shippingPlaceID,
 		ShippingAddressLine1:     params.Checkout.AddressLine1,
 		ShippingAddressLine2:     params.Checkout.AddressLine2,
+		ShippingBarangay:         params.Checkout.Barangay,
 		ShippingCity:             params.Checkout.City,
 		ShippingState:            params.Checkout.Province,
 		ShippingPostalCode:       params.Checkout.Postal,

--- a/internal/server/carts.go
+++ b/internal/server/carts.go
@@ -3,6 +3,7 @@ package server
 import (
 	"cmp"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net"
@@ -58,6 +59,43 @@ type cartSummaryData struct {
 	DeliveryFee   string
 	Total         string
 	DeliveryETA   string
+}
+
+func (s *Server) getCartShippingPrefill(ctx context.Context) models.CartShippingPrefill {
+	customerIDStr := s.sessionManager.GetString(ctx, SessionCustomerID)
+	if customerIDStr == "" {
+		return models.CartShippingPrefill{}
+	}
+
+	if s.encoder.Decode(customerIDStr) == encode.INVALID {
+		return models.CartShippingPrefill{}
+	}
+
+	prefill, err := s.services.customer.GetCartShippingPrefill(ctx, customerIDStr)
+	if err != nil {
+		logs.LogCtx(ctx).Warn(
+			"[Cart Shipping Prefill]",
+			zap.String("customer_id", customerIDStr),
+			zap.Error(err),
+		)
+		return models.CartShippingPrefill{}
+	}
+
+	return prefill
+}
+
+func (s *Server) getSessionCustomerID(ctx context.Context) sql.NullInt64 {
+	customerIDStr := s.sessionManager.GetString(ctx, SessionCustomerID)
+	if customerIDStr == "" {
+		return sql.NullInt64{}
+	}
+
+	decodedID := s.encoder.Decode(customerIDStr)
+	if decodedID == encode.INVALID {
+		return sql.NullInt64{}
+	}
+
+	return sql.NullInt64{Int64: decodedID, Valid: true}
 }
 
 func (s *Server) calculateCartSummary(ctx context.Context) (cartSummaryData, error) {
@@ -196,7 +234,8 @@ func (s *Server) cartsPageHandler(w http.ResponseWriter, r *http.Request) {
 
 	showCPointsBanner := s.sessionManager.GetString(ctx, SessionCustomerID) == ""
 	summaryContent := s.generateCartSummaryComponent(ctx)
-	if err := compcart.CartPage(compcart.CartPageBody(summaryContent, showCPointsBanner)).Render(ctx, w); err != nil {
+	shippingPrefill := s.getCartShippingPrefill(ctx)
+	if err := compcart.CartPage(compcart.CartPageBody(summaryContent, showCPointsBanner, shippingPrefill)).Render(ctx, w); err != nil {
 		logs.LogCtx(ctx).Error(
 			logtag,
 			zap.Error(err),
@@ -758,6 +797,7 @@ func (s *Server) cartsFinalizeHandler(w http.ResponseWriter, r *http.Request) {
 			Cache:                   s.cache,
 			SingleFlight:            &s.SF,
 			Encoder:                 s.encoder,
+			CustomerID:              s.getSessionCustomerID(ctx),
 		}
 
 		order, checkoutURL, err := orders.CreateOrderFromCheckout(ctx, s.dbRW, orderParams)

--- a/internal/services/customer.go
+++ b/internal/services/customer.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 
 	"cchoice/cmd/web/models"
@@ -160,6 +161,44 @@ func (s *CustomerService) BuildProfile(ctx context.Context, customerID string) (
 	}
 
 	return profile, nil
+}
+
+func (s *CustomerService) GetCartShippingPrefill(ctx context.Context, customerID string) (models.CartShippingPrefill, error) {
+	profile, err := s.BuildProfile(ctx, customerID)
+	if err != nil {
+		return models.CartShippingPrefill{}, err
+	}
+
+	prefill := models.CartShippingPrefill{
+		Email:    profile.Email,
+		FullName: profile.FullName,
+		MobileNo: profile.MobileNo,
+	}
+
+	decodedID := s.encoder.Decode(customerID)
+	if decodedID == encode.INVALID {
+		return models.CartShippingPrefill{}, errs.ErrInvalidInput
+	}
+
+	order, err := s.dbRO.GetQueries().GetLatestOrderShippingByCustomerID(ctx, sql.NullInt64{
+		Int64: decodedID,
+		Valid: true,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return prefill, nil
+		}
+		return models.CartShippingPrefill{}, err
+	}
+
+	prefill.AddressLine1 = order.ShippingAddressLine1
+	prefill.AddressLine2 = order.ShippingAddressLine2
+	prefill.Postal = order.ShippingPostalCode
+	prefill.Province = order.ShippingState
+	prefill.City = order.ShippingCity
+	prefill.Barangay = order.ShippingBarangay
+
+	return prefill, nil
 }
 
 func (s *CustomerService) GetAllCustomers(ctx context.Context) ([]CustomerListItem, error) {

--- a/migrations/sqlite3/20260706120000_add_customer_id_to_orders.sql
+++ b/migrations/sqlite3/20260706120000_add_customer_id_to_orders.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+ALTER TABLE tbl_orders ADD COLUMN customer_id INTEGER REFERENCES tbl_customers(id);
+ALTER TABLE tbl_orders ADD COLUMN shipping_barangay TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_orders_customer_id ON tbl_orders(customer_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_orders_customer_id;
+ALTER TABLE tbl_orders DROP COLUMN shipping_barangay;
+ALTER TABLE tbl_orders DROP COLUMN customer_id;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Links orders to logged-in customers by detecting the customer session during checkout finalize and storing `customer_id` on `tbl_orders`.
- Adds `shipping_barangay` to orders so repeat checkouts can restore full Philippine address details.
- Pre-fills the cart shipping form for logged-in customers using their profile (name, email, mobile) and their most recent order shipping address.
- Fixes `customer_name` on order creation to use the checkout full name instead of email.

## Database

Adds migration `migrations/sqlite3/20260706120000_add_customer_id_to_orders.sql`:

- `customer_id` (nullable FK to `tbl_customers`)
- `shipping_barangay` (text, default `''`)
- Index on `customer_id`

**Migration must be applied manually** (`mage dbup`).

## Behavior

1. **Guest checkout** — unchanged; `customer_id` remains null.
2. **Logged-in checkout** — `customer_id` is set from the SCS session when the order is created.
3. **Cart page** — if the customer is logged in and has no in-progress `sessionStorage` shipping state, the form is pre-filled from profile + latest linked order.

## Test plan

- [ ] Apply migration and verify `tbl_orders` has new columns
- [ ] Guest checkout still creates orders with null `customer_id`
- [ ] Logged-in customer checkout sets `customer_id` on the new order
- [ ] Cart shipping form pre-fills profile fields for logged-in customers
- [ ] Cart shipping form pre-fills address from previous order after first linked checkout
- [ ] Existing `sessionStorage` shipping state still takes priority over server prefill
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47a0d3a8-0798-401d-bb14-9cf1168f347d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47a0d3a8-0798-401d-bb14-9cf1168f347d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

